### PR TITLE
add optional triangle dependency (speed up shapes init)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,9 @@ testing =
     napari
     pre-commit>=2.9.0
     towncrier>=21.3.0
+# add optional dependency for faster initialization of shapes layer
+optional =
+    triangle
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
As described in #42 , this PR adds an optional `triangle` dependency that should speed up initialization of the shapes layer.

cc @LucaMarconato 