### PR TITLE
Fixing private module imports

### DIFF
--- a/examples/spatialdata_interactive.py
+++ b/examples/spatialdata_interactive.py
@@ -1,4 +1,4 @@
-from napari_spatialdata._interactive import Interactive
+from napari_spatialdata import Interactive
 from spatialdata import SpatialData
 
 if __name__ == "__main__":

--- a/src/napari_spatialdata/__init__.py
+++ b/src/napari_spatialdata/__init__.py
@@ -12,6 +12,7 @@ except ImportError:
 
 del version, parse
 
+from napari_spatialdata._interactive import Interactive as Interactive  # noqa: E402
 from napari_spatialdata._view import (  # noqa: E402
     QtAdataScatterWidget,
     QtAdataViewWidget,


### PR DESCRIPTION
Replacing `napari_spatialdata._interactive import Interactive` with `from napari_spatialdata import Interactive`