### PR TITLE
Fixes performance with multiscale, fixes docs

### DIFF
--- a/src/napari_spatialdata/_interactive.py
+++ b/src/napari_spatialdata/_interactive.py
@@ -7,12 +7,11 @@ import numpy as np
 import shapely
 from anndata import AnnData
 from loguru import logger
-from multiscale_spatial_image import MultiscaleSpatialImage
 from napari.viewer import Viewer
 from qtpy.QtWidgets import QLabel, QListWidget, QListWidgetItem, QVBoxLayout, QWidget
 from spatialdata import SpatialData
 
-from napari_spatialdata.utils._utils import NDArrayA, _get_transform, _swap_coordinates, _transform_to_rgb
+from napari_spatialdata.utils._utils import NDArrayA, _adjust_channels_order, _get_transform, _swap_coordinates
 
 if TYPE_CHECKING:
     from napari.utils.events.event import Event
@@ -213,7 +212,7 @@ class SdataWidget(QWidget):
         selected_cs = self.coordinate_system_widget._system
         affine = _get_transform(self._sdata.labels[key], selected_cs)
 
-        rgb_labels, _ = _transform_to_rgb(element=self._sdata.labels[key])
+        rgb_labels, _ = _adjust_channels_order(element=self._sdata.labels[key])
 
         layer = self._viewer.add_labels(
             rgb_labels,
@@ -232,12 +231,10 @@ class SdataWidget(QWidget):
 
     def _add_image(self, key: str) -> None:
         selected_cs = self.coordinate_system_widget._system
-        img = self._sdata.images[key]
+        self._sdata.images[key]
         affine = _get_transform(self._sdata.images[key], selected_cs)
-        rgb_image, rgb = _transform_to_rgb(element=self._sdata.images[key])
+        rgb_image, rgb = _adjust_channels_order(element=self._sdata.images[key])
 
-        if isinstance(img, MultiscaleSpatialImage):
-            rgb_image = rgb_image[0]
         # TODO: type check
         layer = self._viewer.add_image(
             rgb_image, rgb=rgb, name=key, affine=affine, metadata={"_active_in_cs": {selected_cs}}

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -227,11 +227,11 @@ def _points_inside_triangles(points: NDArrayA, triangles: NDArrayA) -> NDArrayA:
     return out
 
 
-def _transform_to_rgb(element: SpatialImage | MultiscaleSpatialImage) -> tuple[DataArray, bool]:
-    """Swap the axes to y, x, c if an image supports rgb(a) visualization.
+def _adjust_channels_order(element: SpatialImage | MultiscaleSpatialImage) -> tuple[DataArray, bool]:
+    """Swap the axes to y, x, c and check if an image supports rgb(a) visualization.
 
-    Checks whether c dim is present in the axes and allows for rgb(a) visualization. If so, subsequently transposes it
-    into (c, y, x) axis order and flags as suitable for rgb visualization.
+    Checks whether c dim is present in the axes and if so, transposes the dimensions to have c last.
+    If the dimension of c is 3 or 4, it is assumed that the image is suitable for rgb(a) visualization.
 
     Parameters
     ----------

--- a/tests/test_spatialdata.py
+++ b/tests/test_spatialdata.py
@@ -56,7 +56,7 @@ def test_sdatawidget_images(make_napari_viewer: Any):
     widget.elements_widget._onClickChange("global")
     widget._onClick("image")
     assert len(widget._viewer.layers) == 2
-    assert (widget._viewer.layers[0].data == widget._viewer.layers[1].data).all()
+    assert (widget._viewer.layers[0].data == widget._viewer.layers[1].data._data[0]).all()
     del sdata.images["image"]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,13 +5,13 @@ import numpy as np
 import pytest
 from anndata import AnnData
 from napari_spatialdata.utils._utils import (
+    _adjust_channels_order,
     _get_categorical,
     _get_transform,
     _min_max_norm,
     _points_inside_triangles,
     _position_cluster_labels,
     _set_palette,
-    _transform_to_rgb,
 )
 from spatialdata.datasets import blobs
 
@@ -105,8 +105,8 @@ def test_get_transform():
 @pytest.mark.parametrize("n_channels", [3, 4, 5])
 def test_transform_to_rgb(n_channels):
     sdata = blobs(n_channels=n_channels)
-    raster, rgb = _transform_to_rgb(sdata.images["blobs_image"])
-    raster_multiscales, rgb_multiscales = _transform_to_rgb(sdata.images["blobs_multiscale_image"])
+    raster, rgb = _adjust_channels_order(sdata.images["blobs_image"])
+    raster_multiscales, rgb_multiscales = _adjust_channels_order(sdata.images["blobs_multiscale_image"])
     if n_channels not in (3, 4):
         assert not rgb
         assert not rgb_multiscales


### PR DESCRIPTION
* Fixes performance issue with multiscale images. Performance tested on the Xenium + Visium dataset (the one where the performance problem got reported)
	* closes https://github.com/scverse/napari-spatialdata/issues/126
	* closes https://github.com/scverse/napari-spatialdata/issues/125
* Refactor the name and the docstring of `_transform_to_rgb()`, now called `_adjust_channels_order()`, as the name was misleading. The function is not transforming to RGB, but it's swapping the dims and telling if the image is RGB or not. Also the swap of the dims is done all the time a `c` dimension is present and not just when an RGB image is passed, as the old docstring suggested.