### PR TITLE
Improved ergonomics of `Interactive`

### DIFF
--- a/src/napari_spatialdata/__main__.py
+++ b/src/napari_spatialdata/__main__.py
@@ -62,9 +62,7 @@ def view(path: tuple[str], headless: bool) -> None:
         break
 
     # TODO: remove [0] when multiple datasets are supported
-    interactive = Interactive(sdata=sdatas[0])
-    if not headless:
-        interactive.run()
+    Interactive(sdata=sdatas[0], headless=headless)
 
 
 if __name__ == "__main__":

--- a/src/napari_spatialdata/_interactive.py
+++ b/src/napari_spatialdata/_interactive.py
@@ -19,13 +19,15 @@ class Interactive:
     ----------
     sdata
         SpatialData object.
+    headless
+        Run napari in headless mode, default False.
 
     Returns
     -------
     None
     """
 
-    def __init__(self, sdata: SpatialData):
+    def __init__(self, sdata: SpatialData, headless: bool = False) -> None:
         viewer = napari.current_viewer()
         self._viewer = viewer if viewer else napari.Viewer()
         self._sdata = sdata
@@ -33,6 +35,9 @@ class Interactive:
         self._list_widget = self._viewer.window.add_dock_widget(
             self._sdata_widget, name="SpatialData", area="left", menu=self._viewer.window.window_menu
         )
+        self._viewer.window.add_plugin_dock_widget("napari-spatialdata", "View")
+        if not headless:
+            self.run()
 
     def run(self) -> None:
         napari.run()


### PR DESCRIPTION
Small PR.
- [x] added the argument `headless: bool = False` to `Interactive.__init__()`. When `False`, the initializer calls `self.run()`. This is a small ergonomics improvement for the user since `interactive.run()` will be always called, and if for some reasons is not needed (like tests with napari being healess), this is still possible thanks to the new argument.
- [x] the `View` widget is now displayed by default. Reasons: the users will almost always want to show the `View` widget so better to show it by default. 