### PR TITLE
Transform layers

### DIFF
--- a/src/napari_spatialdata/_sdata_widgets.py
+++ b/src/napari_spatialdata/_sdata_widgets.py
@@ -64,6 +64,9 @@ class SdataWidget(QWidget):
             lambda item: self.coordinate_system_widget._select_coord_sys(item.text())
         )
         self.coordinate_system_widget.itemClicked.connect(self._update_layers_visibility)
+        self.coordinate_system_widget.itemClicked.connect(
+            lambda item: self.viewer_model._affine_transform_layers(item.text())
+        )
         self.viewer_model.viewer.layers.events.inserted.connect(self._on_insert_layer)
 
     def _on_insert_layer(self, event: Event) -> None:

--- a/src/napari_spatialdata/_sdata_widgets.py
+++ b/src/napari_spatialdata/_sdata_widgets.py
@@ -105,13 +105,15 @@ class SdataWidget(QWidget):
         # No layer selected on first time coordinate system selection
         if self.viewer_model.viewer.layers:
             for layer in self.viewer_model.viewer.layers:
-                if layer.name not in elements:
-                    layer.visible = False
-                elif layer.metadata["_active_in_cs"]:
-                    layer.visible = True
-                    # Prevent _update_visible_in_coordinate_system of invalid removal of coordinate system
-                    layer.metadata["_active_in_cs"].add(coordinate_system)
-                    layer.metadata["_current_cs"] = coordinate_system
+                element_name = layer.metadata.get("name")
+                if element_name:
+                    if layer.name not in elements:
+                        layer.visible = False
+                    elif layer.metadata["_active_in_cs"]:
+                        layer.visible = True
+                        # Prevent _update_visible_in_coordinate_system of invalid removal of coordinate system
+                        layer.metadata["_active_in_cs"].add(coordinate_system)
+                        layer.metadata["_current_cs"] = coordinate_system
 
     def _add_circles(self, key: str) -> None:
         selected_cs = self.coordinate_system_widget._system

--- a/src/napari_spatialdata/_sdata_widgets.py
+++ b/src/napari_spatialdata/_sdata_widgets.py
@@ -85,12 +85,13 @@ class SdataWidget(QWidget):
 
     def _update_visible_in_coordinate_system(self, event: Event) -> None:
         """Toggle active in the coordinate system metadata when changing visibility of layer."""
-        layer = event.source
-        layer_active = layer.metadata["_active_in_cs"]
+        metadata = event.source.metadata
+        layer_active = metadata.get("_active_in_cs")
         selected_coordinate_system = self.coordinate_system_widget._system
 
         elements = self.elements_widget._elements
-        if layer.name in elements:
+        element_name = metadata.get("name")
+        if element_name and element_name in elements:
             if selected_coordinate_system not in layer_active:
                 layer_active.add(selected_coordinate_system)
             else:

--- a/src/napari_spatialdata/_sdata_widgets.py
+++ b/src/napari_spatialdata/_sdata_widgets.py
@@ -107,7 +107,7 @@ class SdataWidget(QWidget):
             for layer in self.viewer_model.viewer.layers:
                 element_name = layer.metadata.get("name")
                 if element_name:
-                    if layer.name not in elements:
+                    if element_name not in elements:
                         layer.visible = False
                     elif layer.metadata["_active_in_cs"]:
                         layer.visible = True

--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -75,7 +75,7 @@ class SpatialDataViewer:
             rgb=rgb,
             name=key,
             affine=affine,
-            metadata={"sdata": sdata, "_active_in_cs": {selected_cs}, "_current_cs": selected_cs},
+            metadata={"sdata": sdata, "name": key, "_active_in_cs": {selected_cs}, "_current_cs": selected_cs},
         )
 
     def add_sdata_circles(self, sdata: SpatialData, selected_cs: str, key: str) -> None:
@@ -184,3 +184,14 @@ class SpatialDataViewer:
                 "_current_cs": selected_cs,
             },
         )
+
+    def _affine_transform_layers(self, coordinate_system: str) -> None:
+        for layer in self.viewer.layers:
+            metadata = layer.metadata
+            if metadata.get("sdata"):
+                sdata = metadata["sdata"]
+                element_name = metadata["name"]
+                element_data = sdata[element_name]
+                affine = _get_transform(element_data, coordinate_system)
+                if affine is not None:
+                    layer.affine = affine

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -179,7 +179,7 @@ def _swap_coordinates(data: list[Any]) -> list[Any]:
 
 
 def _get_transform(element: SpatialElement, coordinate_system_name: str | None = None) -> None | NDArrayA:
-    if not isinstance(element, (SpatialImage, MultiscaleSpatialImage, AnnData, DaskDataFrame, GeoDataFrame)):
+    if not isinstance(element, (SpatialImage, MultiscaleSpatialImage, DaskDataFrame, GeoDataFrame)):
         raise RuntimeError("Cannot get transform for {type(element)}")
 
     transformations = get_transformation(element, get_all=True)

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -179,8 +179,6 @@ def _swap_coordinates(data: list[Any]) -> list[Any]:
 
 
 def _get_transform(element: SpatialElement, coordinate_system_name: str | None = None) -> None | NDArrayA:
-    affine: NDArrayA
-
     if not isinstance(element, (SpatialImage, MultiscaleSpatialImage, AnnData, DaskDataFrame, GeoDataFrame)):
         raise RuntimeError("Cannot get transform for {type(element)}")
 
@@ -188,9 +186,8 @@ def _get_transform(element: SpatialElement, coordinate_system_name: str | None =
     cs = transformations.keys().__iter__().__next__() if coordinate_system_name is None else coordinate_system_name
     ct = transformations.get(cs)
     if ct:
-        affine = ct.to_affine_matrix(input_axes=("y", "x"), output_axes=("y", "x"))
-
-    return affine
+        return ct.to_affine_matrix(input_axes=("y", "x"), output_axes=("y", "x"))  # type: ignore
+    return None
 
 
 @njit(cache=True, fastmath=True)

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -178,24 +178,18 @@ def _swap_coordinates(data: list[Any]) -> list[Any]:
     return [[(y, x) for x, y in sublist] for sublist in data]
 
 
-def _get_transform(element: SpatialElement, coordinate_system_name: str | None = None) -> NDArrayA:
+def _get_transform(element: SpatialElement, coordinate_system_name: str | None = None) -> None | NDArrayA:
     affine: NDArrayA
-    transformations = get_transformation(element, get_all=True)
-    cs = transformations.keys().__iter__().__next__() if coordinate_system_name is None else coordinate_system_name
-    ct = transformations[cs]
-    affine = ct.to_affine_matrix(input_axes=("y", "x"), output_axes=("y", "x"))
 
     if not isinstance(element, (SpatialImage, MultiscaleSpatialImage, AnnData, DaskDataFrame, GeoDataFrame)):
         raise RuntimeError("Cannot get transform for {type(element)}")
-    # elif isinstance(element, (AnnData, DaskDataFrame, GeoDataFrame)):
-    #    return affine
-    #    from spatialdata.transformations import Affine, Sequence, MapAxis
-    #    new_affine = Sequence(
-    #        [MapAxis({"x": "y", "y": "x"}), Affine(affine, input_axes=("y", "x"), output_axes=("y", "x"))]
-    #    )
-    #    new_matrix = new_affine.to_affine_matrix(input_axes=("y", "x"), output_axes=("y", "x"))
 
-    #    return new_matrix
+    transformations = get_transformation(element, get_all=True)
+    cs = transformations.keys().__iter__().__next__() if coordinate_system_name is None else coordinate_system_name
+    ct = transformations.get(cs)
+    if ct:
+        affine = ct.to_affine_matrix(input_axes=("y", "x"), output_axes=("y", "x"))
+
     return affine
 
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,6 +1,9 @@
+import numpy as np
 from napari_spatialdata._sdata_widgets import SdataWidget
 from napari_spatialdata.utils._test_utils import click_list_widget_item, get_center_pos_listitem
+from napari_spatialdata.utils._utils import _get_transform
 from spatialdata.datasets import blobs
+from spatialdata.transformations import Translation, set_transformation
 
 sdata = blobs(extra_coord_system="space")
 
@@ -30,3 +33,30 @@ def test_metadata_inheritance(qtbot, make_napari_viewer: any):
     assert all(sdatas[0] is sdata for sdata in sdatas[1:])
     assert viewer.layers[-1].metadata["_current_cs"] == "global"
     assert viewer.layers[-1].metadata["_active_in_cs"] == {"global"}
+
+
+def test_layer_transform(qtbot, make_napari_viewer: any):
+    set_transformation(
+        sdata["blobs_image"], transformation=Translation([25, 50], axes=("y", "x")), to_coordinate_system="translate"
+    )
+    viewer = make_napari_viewer()
+    widget = SdataWidget(viewer, sdata)
+
+    # Click on `global` coordinate system
+    center_pos = get_center_pos_listitem(widget.coordinate_system_widget, "global")
+    click_list_widget_item(qtbot, widget.coordinate_system_widget, center_pos, "currentItemChanged")
+
+    widget._add_image(list(sdata.images.keys())[0])
+    viewer.add_image(viewer.layers[0].data)
+
+    no_transform = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    affine_transform = _get_transform(sdata[list(sdata.images.keys())[0]], "translate")
+    assert np.array_equal(viewer.layers[0].affine.affine_matrix, no_transform)
+    assert np.array_equal(viewer.layers[1].affine.affine_matrix, no_transform)
+
+    # Click on `global` coordinate system
+    center_pos = get_center_pos_listitem(widget.coordinate_system_widget, "translate")
+    click_list_widget_item(qtbot, widget.coordinate_system_widget, center_pos, "currentItemChanged")
+
+    assert np.array_equal(viewer.layers[0].affine.affine_matrix, affine_transform)
+    assert np.array_equal(viewer.layers[1].affine.affine_matrix, no_transform)


### PR DESCRIPTION
This PR allows for the affine transform associated with the layer(s) to be updated when the coordinate system is changed. It will ignore layers that do not have an `sdata` object associated with them. 

Furthermore, this PR includes a bugfix for the issue of  a `KeyError` being raised when the visibility of the layer is updated and the layer has no `sdata` associated with it.