### PR TITLE
Add element api

### DIFF
--- a/src/napari_spatialdata/_interactive.py
+++ b/src/napari_spatialdata/_interactive.py
@@ -10,6 +10,7 @@ from napari_spatialdata.utils._utils import (
     NDArrayA,
     get_duplicate_element_names,
     get_elements_meta_mapping,
+    get_itemindex_by_text,
 )
 
 if TYPE_CHECKING:
@@ -32,29 +33,34 @@ class Interactive:
     None
     """
 
-    def add_element(self, coordinate_system_name: str, element: str) -> None:
+    def add_element(self, element: str, element_coordinate_system: str, view_element_system: bool = False) -> None:
         duplicate_element_names, _ = get_duplicate_element_names(self._sdata)
         elements, name_to_add = get_elements_meta_mapping(
-            self._sdata, coordinate_system_name, duplicate_element_names, element
+            self._sdata, element_coordinate_system, duplicate_element_names, element
         )
         if name_to_add:
-            cache_elements = self._sdata_widget.elements_widget._elements
-            cache_coordinate_system = self._sdata_widget.coordinate_system_widget._system
-            self._sdata_widget.elements_widget._elements = elements
-            self._sdata_widget.coordinate_system_widget._system = coordinate_system_name
-            self._sdata_widget._onClick(name_to_add)
-            self._sdata_widget.elements_widget._elements = cache_elements
-            self._sdata_widget.coordinate_system_widget._system = cache_coordinate_system
+            if view_element_system:
+                widget_item = get_itemindex_by_text(
+                    self._sdata_widget.coordinate_system_widget, element_coordinate_system
+                )
+                self._sdata_widget.coordinate_system_widget.setCurrentItem(widget_item)
+                self._sdata_widget._onClick(name_to_add)
+            else:
+                cache_elements = self._sdata_widget.elements_widget._elements
+                cache_coordinate_system = self._sdata_widget.coordinate_system_widget._system
+                self._sdata_widget.elements_widget._elements = elements
+                self._sdata_widget.coordinate_system_widget._system = element_coordinate_system
+                self._sdata_widget._onClick(name_to_add)
+                self._sdata_widget.elements_widget._elements = cache_elements
+                self._sdata_widget.coordinate_system_widget._system = cache_coordinate_system
+                self._viewer.layers[-1].visible = True
         else:
-            raise ValueError(f"Element {element} not found in coordinate system {coordinate_system_name}.")
+            raise ValueError(f"Element {element} not found in coordinate system {element_coordinate_system}.")
 
     def switch_coordinate_system(self, coordinate_system: str) -> None:
-        for index in range(self._sdata_widget.coordinate_system_widget.count()):
-            widget_item_text = self._sdata_widget.coordinate_system_widget.item(index).text()
-            if widget_item_text == coordinate_system:
-                widget_item = self._sdata_widget.coordinate_system_widget.item(index)
-                self._sdata_widget.coordinate_system_widget.setCurrentItem(widget_item)
-                break
+        widget_item = get_itemindex_by_text(self._sdata_widget.coordinate_system_widget, coordinate_system)
+        if widget_item:
+            self._sdata_widget.coordinate_system_widget.setCurrentItem(widget_item)
         else:
             raise ValueError(f"{coordinate_system} not present as coordinate system in any of the spatialdata objects")
 

--- a/src/napari_spatialdata/_interactive.py
+++ b/src/napari_spatialdata/_interactive.py
@@ -49,14 +49,14 @@ class Interactive:
             raise ValueError(f"Element {element} not found in coordinate system {coordinate_system_name}.")
 
     def switch_coordinate_system(self, coordinate_system: str) -> None:
-        coordinate_systems = {cs for sdata in self._sdata for cs in sdata.coordinate_systems}
-        if coordinate_system not in coordinate_systems:
-            raise ValueError(f"{coordinate_system} not present as coordinate system in any of the spatialdata objects")
-        for index, cs in enumerate(coordinate_systems):
+        for index in range(self._sdata_widget.coordinate_system_widget.count()):
             widget_item_text = self._sdata_widget.coordinate_system_widget.item(index).text()
-            if widget_item_text == cs:
+            if widget_item_text == coordinate_system:
                 widget_item = self._sdata_widget.coordinate_system_widget.item(index)
                 self._sdata_widget.coordinate_system_widget.setCurrentItem(widget_item)
+                break
+        else:
+            raise ValueError(f"{coordinate_system} not present as coordinate system in any of the spatialdata objects")
 
     def __init__(self, sdata: SpatialData | list[SpatialData], headless: bool = False):
         viewer = napari.current_viewer()

--- a/src/napari_spatialdata/_interactive.py
+++ b/src/napari_spatialdata/_interactive.py
@@ -64,16 +64,6 @@ class Interactive:
         else:
             raise ValueError(f"{coordinate_system} not present as coordinate system in any of the spatialdata objects")
 
-    def switch_coordinate_system(self, coordinate_system: str) -> None:
-        coordinate_systems = {cs for sdata in self._sdata for cs in sdata.coordinate_systems}
-        if coordinate_system not in coordinate_systems:
-            raise ValueError(f"{coordinate_system} not present as coordinate system in any of the spatialdata objects")
-        for index, cs in enumerate(coordinate_systems):
-            widget_item_text = self._sdata_widget.coordinate_system_widget.item(index).text()
-            if widget_item_text == cs:
-                widget_item = self._sdata_widget.coordinate_system_widget.item(index)
-                self._sdata_widget.coordinate_system_widget.setCurrentItem(widget_item)
-
     def __init__(self, sdata: SpatialData | list[SpatialData], headless: bool = False):
         viewer = napari.current_viewer()
         self._viewer = viewer if viewer else napari.Viewer()

--- a/src/napari_spatialdata/_interactive.py
+++ b/src/napari_spatialdata/_interactive.py
@@ -48,6 +48,16 @@ class Interactive:
         else:
             raise ValueError(f"Element {element} not found in coordinate system {coordinate_system_name}.")
 
+    def switch_coordinate_system(self, coordinate_system: str) -> None:
+        coordinate_systems = {cs for sdata in self._sdata for cs in sdata.coordinate_systems}
+        if coordinate_system not in coordinate_systems:
+            raise ValueError(f"{coordinate_system} not present as coordinate system in any of the spatialdata objects")
+        for index, cs in enumerate(coordinate_systems):
+            widget_item_text = self._sdata_widget.coordinate_system_widget.item(index).text()
+            if widget_item_text == cs:
+                widget_item = self._sdata_widget.coordinate_system_widget.item(index)
+                self._sdata_widget.coordinate_system_widget.setCurrentItem(widget_item)
+
     def __init__(self, sdata: SpatialData | list[SpatialData], headless: bool = False):
         viewer = napari.current_viewer()
         self._viewer = viewer if viewer else napari.Viewer()

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -22,7 +22,6 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_string_dtype,
 )
-from qtpy.QtWidgets import QListWidgetItem
 from scipy.sparse import issparse, spmatrix
 from scipy.spatial import KDTree
 from spatial_image import SpatialImage
@@ -37,7 +36,10 @@ from napari_spatialdata.utils._categoricals_utils import (
 
 if TYPE_CHECKING:
     from napari.utils.events import EventedList
+    from qtpy.QtWidgets import QListWidgetItem
     from xarray import DataArray
+
+    from napari_spatialdata._sdata_widgets import CoordinateSystemWidget, ElementWidget
 
 try:
     from numpy.typing import NDArray
@@ -367,3 +369,14 @@ def get_elements_meta_mapping(
                 name_to_add = name
             elements[name] = elements_metadata
     return elements, name_to_add
+
+
+def get_itemindex_by_text(
+    list_widget: CoordinateSystemWidget | ElementWidget, item_text: str
+) -> None | QListWidgetItem:
+    widget_item = None
+    for index in range(list_widget.count()):
+        widget_item_text = list_widget.item(index).text()
+        if widget_item_text == item_text:
+            widget_item = list_widget.item(index)
+    return widget_item

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -26,3 +26,4 @@ class TestImages(PlotTester, metaclass=PlotTesterMeta):
         i.switch_coordinate_system("global")
         assert i._sdata_widget.coordinate_system_widget._system == "global"
         assert i._sdata_widget.elements_widget._elements
+        i._viewer.close()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -19,7 +19,7 @@ class TestImages(PlotTester, metaclass=PlotTesterMeta):
         i.add_element(coordinate_system_name="global", element="blobs_labels")
         i.add_element(coordinate_system_name="global", element="blobs_circles")
 
-    def test_switch_coorindate_system(self, sdata_blobs: SpatialData):
+    def test_switch_coordinate_system(self, sdata_blobs: SpatialData):
         i = Interactive(sdata=sdata_blobs, headless=True)
         assert not i._sdata_widget.coordinate_system_widget._system
         assert not i._sdata_widget.elements_widget._elements

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -38,3 +38,4 @@ def test_plot_can_add_element_switch_cs(sdata_blobs: SpatialData):
     i.add_element(element="blobs_image", element_coordinate_system="global", view_element_system=True)
     assert i._sdata_widget.coordinate_system_widget._system == "global"
     assert i._viewer.layers[-1].visible
+    i._viewer.close()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -18,3 +18,11 @@ class TestImages(PlotTester, metaclass=PlotTesterMeta):
         i.add_element(coordinate_system_name="global", element="blobs_image")
         i.add_element(coordinate_system_name="global", element="blobs_labels")
         i.add_element(coordinate_system_name="global", element="blobs_circles")
+
+    def test_switch_coorindate_system(self, sdata_blobs: SpatialData):
+        i = Interactive(sdata=sdata_blobs, headless=True)
+        assert not i._sdata_widget.coordinate_system_widget._system
+        assert not i._sdata_widget.elements_widget._elements
+        i.switch_coordinate_system("global")
+        assert i._sdata_widget.coordinate_system_widget._system == "global"
+        assert i._sdata_widget.elements_widget._elements

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -7,17 +7,21 @@ from tests.conftest import PlotTester, PlotTesterMeta
 class TestImages(PlotTester, metaclass=PlotTesterMeta):
     def test_plot_can_add_element_image(self, sdata_blobs: SpatialData):
         i = Interactive(sdata=sdata_blobs, headless=True)
-        i.add_element(coordinate_system_name="global", element="blobs_image")
+        i.add_element(element="blobs_image", element_coordinate_system="global")
 
     def test_plot_can_add_element_label(self, sdata_blobs: SpatialData):
         i = Interactive(sdata=sdata_blobs, headless=True)
-        i.add_element(coordinate_system_name="global", element="blobs_labels")
+        i.add_element(element="blobs_labels", element_coordinate_system="global")
 
     def test_plot_can_add_element_multiple(self, sdata_blobs: SpatialData):
         i = Interactive(sdata=sdata_blobs, headless=True)
-        i.add_element(coordinate_system_name="global", element="blobs_image")
-        i.add_element(coordinate_system_name="global", element="blobs_labels")
-        i.add_element(coordinate_system_name="global", element="blobs_circles")
+        i.add_element(element="blobs_image", element_coordinate_system="global")
+        i.add_element(element="blobs_labels", element_coordinate_system="global")
+        i.add_element(element="blobs_circles", element_coordinate_system="global")
+        assert not i._sdata_widget.coordinate_system_widget._system
+        assert not i._sdata_widget.elements_widget._elements
+        for layer in i._viewer.layers:
+            assert layer.visible
 
     def test_switch_coordinate_system(self, sdata_blobs: SpatialData):
         i = Interactive(sdata=sdata_blobs, headless=True)
@@ -27,3 +31,10 @@ class TestImages(PlotTester, metaclass=PlotTesterMeta):
         assert i._sdata_widget.coordinate_system_widget._system == "global"
         assert i._sdata_widget.elements_widget._elements
         i._viewer.close()
+
+
+def test_plot_can_add_element_switch_cs(sdata_blobs: SpatialData):
+    i = Interactive(sdata=sdata_blobs, headless=True)
+    i.add_element(element="blobs_image", element_coordinate_system="global", view_element_system=True)
+    assert i._sdata_widget.coordinate_system_widget._system == "global"
+    assert i._viewer.layers[-1].visible


### PR DESCRIPTION
Closes #159 

This is a follow up PR of #169 and should finish the last task of #159. When adding an element now the element will always be visible even when the element is not present in the current `coordinate_system`. However, if `view_element_system` is set to `True`, it is switched to the `coordinate_system` specified by the user for viewing the element.