### PR TITLE
add_globals

### DIFF
--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
     from napari.utils.events import Event, EventedList
     from spatialdata import SpatialData
 
+POLYGON_THRESHOLD = 100
+POINT_THRESHOLD = 100000
+
 
 class SpatialDataViewer:
     def __init__(self, viewer: Viewer, sdata: EventedList) -> None:
@@ -185,7 +188,7 @@ class SpatialDataViewer:
             df = df.sort_values(by="area", ascending=False)  # sort by area
             df = df[~df.index.duplicated(keep="first")]  # only keep the largest area
             df = df.sort_index()  # reset the index to the first order
-        if len(df) < 100:
+        if len(df) < POLYGON_THRESHOLD:
             for i in range(0, len(df)):
                 polygons.append(list(df.geometry.iloc[i].exterior.coords))
         else:
@@ -240,7 +243,7 @@ class SpatialDataViewer:
 
         points = sdata.points[original_name].compute()
         affine = _get_transform(sdata.points[original_name], selected_cs)
-        if len(points) < 100000:
+        if len(points) < POINT_THRESHOLD:
             subsample = np.arange(len(points))
         else:
             logger.info("Subsampling points because the number of points exceeds the currently supported 100 000.")


### PR DESCRIPTION
closes #94 

Add global variables to allow users to adjust the `POLYGON_TRESHOLD` and `POINTS_TRESHOLD` when required.