### PR TITLE
Plotting annotations fix

### DIFF
--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -252,12 +252,6 @@ class QtAdataViewWidget(QWidget):
                 self.model.adata.obsm[Key.obsm.spatial][:, ::-1][:, :2], 0, values=0, axis=1
             )
 
-        if "points" in layer.metadata:
-            # TODO: Check if this can be removed
-            self.model.points_coordinates = layer.metadata["points"].X
-            self.model.points_var = layer.metadata["points"].obs["gene"]
-            self.model.point_diameter = np.array([0.0] + [layer.metadata["point_diameter"]] * 2) * self.model.scale
-
         self.model.spot_diameter = np.array([0.0, 10.0, 10.0])
         self.model._labels_key = layer.metadata["region_key"] if isinstance(layer, Labels) else None
         self.model.system_name = layer.metadata["name"] if "name" in layer.metadata else None

--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -256,8 +256,6 @@ class QtAdataViewWidget(QWidget):
         self.model._labels_key = layer.metadata["region_key"] if isinstance(layer, Labels) else None
         self.model.system_name = layer.metadata["name"] if "name" in layer.metadata else None
 
-        if "colormap" in layer.metadata:
-            self.model.cmap = layer.metadata["colormap"]
         if hasattr(
             self, "obs_widget"
         ):  # to check if the widget has been already initialized, layer update should only be called on layer change

--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -12,6 +12,7 @@ from napari.utils.notifications import show_info
 
 from napari_spatialdata.utils._utils import (
     _adjust_channels_order,
+    _get_metadata_adata,
     _get_transform,
     _swap_coordinates,
     get_duplicate_element_names,
@@ -152,6 +153,7 @@ class SpatialDataViewer:
         xy = np.array([df.geometry.x, df.geometry.y]).T
         xy = np.fliplr(xy)
         radii = df.radius.to_numpy()
+        adata = _get_metadata_adata(sdata, original_name)
 
         self.viewer.add_points(
             xy,
@@ -161,9 +163,7 @@ class SpatialDataViewer:
             edge_width=0.0,
             metadata={
                 "sdata": sdata,
-                "adata": sdata.table[
-                    sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == original_name
-                ],
+                "adata": adata,
                 "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"],
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
@@ -198,6 +198,7 @@ class SpatialDataViewer:
                 polygons.append(list(df.geometry.iloc[i].exterior.simplify(tolerance=2).coords))
         # this will only work for polygons and not for multipolygons
         polygons = _swap_coordinates(polygons)
+        adata = _get_metadata_adata(sdata, key)
 
         self.viewer.add_shapes(
             polygons,
@@ -206,7 +207,7 @@ class SpatialDataViewer:
             shape_type="polygon",
             metadata={
                 "sdata": sdata,
-                "adata": sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key],
+                "adata": adata,
                 "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"],
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
@@ -221,6 +222,7 @@ class SpatialDataViewer:
 
         affine = _get_transform(sdata.labels[original_name], selected_cs)
         rgb_labels, _ = _adjust_channels_order(element=sdata.labels[original_name])
+        adata = _get_metadata_adata(sdata, key)
 
         self.viewer.add_labels(
             rgb_labels,
@@ -228,7 +230,7 @@ class SpatialDataViewer:
             affine=affine,
             metadata={
                 "sdata": sdata,
-                "adata": sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key],
+                "adata": adata,
                 "region_key": sdata.table.uns["spatialdata_attrs"]["instance_key"],
                 "name": original_name,
                 "_active_in_cs": {selected_cs},

--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -164,7 +164,7 @@ class SpatialDataViewer:
             metadata={
                 "sdata": sdata,
                 "adata": adata,
-                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"],
+                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"] if sdata.table else None,
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
                 "_current_cs": selected_cs,
@@ -208,7 +208,7 @@ class SpatialDataViewer:
             metadata={
                 "sdata": sdata,
                 "adata": adata,
-                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"],
+                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"] if sdata.table else None,
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
                 "_current_cs": selected_cs,
@@ -231,7 +231,7 @@ class SpatialDataViewer:
             metadata={
                 "sdata": sdata,
                 "adata": adata,
-                "region_key": sdata.table.uns["spatialdata_attrs"]["instance_key"],
+                "region_key": sdata.table.uns["spatialdata_attrs"]["instance_key"] if sdata.table else None,
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
                 "_current_cs": selected_cs,

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -367,3 +367,15 @@ def get_elements_meta_mapping(
                 name_to_add = name
             elements[name] = elements_metadata
     return elements, name_to_add
+
+
+def _get_metadata_adata(sdata: SpatialData, key: str) -> None | AnnData:
+    """
+    Retrieve AnnData to be used in layer metadata.
+
+    Get the AnnData table in the SpatialData object based on the element
+    """
+    adata = sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key]
+    if adata.shape[0] == 0:
+        return None
+    return adata

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -375,7 +375,10 @@ def _get_metadata_adata(sdata: SpatialData, key: str) -> None | AnnData:
 
     Get the AnnData table in the SpatialData object based on the element
     """
-    adata = sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key]
-    if adata.shape[0] == 0:
+    if sdata.table:
+        adata = sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key]
+        if adata.shape[0] == 0:
+            return None
+    else:
         return None
     return adata

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -82,3 +82,19 @@ def test_layer_transform(qtbot, make_napari_viewer: any):
 
     assert np.array_equal(viewer.layers[0].affine.affine_matrix, affine_transform)
     assert np.array_equal(viewer.layers[1].affine.affine_matrix, no_transform)
+
+
+def test_adata_metadata(qtbot, make_napari_viewer: any):
+    viewer = make_napari_viewer()
+    widget = SdataWidget(viewer, EventedList([sdata]))
+
+    # Click on `global` coordinate system
+    center_pos = get_center_pos_listitem(widget.coordinate_system_widget, "global")
+    click_list_widget_item(qtbot, widget.coordinate_system_widget, center_pos, "currentItemChanged")
+
+    widget._onClick("blobs_labels")
+    assert viewer.layers[-1].metadata["adata"]
+
+    # Filtering adata leads to 0 rows so adata should be set to None
+    widget._onClick("blobs_polygons")
+    assert not viewer.layers[-1].metadata["adata"]

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from napari.utils.events import EventedList
+from napari_spatialdata import QtAdataViewWidget
 from napari_spatialdata._sdata_widgets import SdataWidget
 from napari_spatialdata.utils._test_utils import click_list_widget_item, get_center_pos_listitem
 from napari_spatialdata.utils._utils import _get_transform
@@ -87,6 +88,7 @@ def test_layer_transform(qtbot, make_napari_viewer: any):
 def test_adata_metadata(qtbot, make_napari_viewer: any):
     viewer = make_napari_viewer()
     widget = SdataWidget(viewer, EventedList([sdata]))
+    view_widget = QtAdataViewWidget(viewer)
 
     # Click on `global` coordinate system
     center_pos = get_center_pos_listitem(widget.coordinate_system_widget, "global")
@@ -94,7 +96,9 @@ def test_adata_metadata(qtbot, make_napari_viewer: any):
 
     widget._onClick("blobs_labels")
     assert viewer.layers[-1].metadata["adata"]
+    assert view_widget.obs_widget.item(0)
 
     # Filtering adata leads to 0 rows so adata should be set to None
     widget._onClick("blobs_polygons")
     assert not viewer.layers[-1].metadata["adata"]
+    assert not view_widget.obs_widget.item(0)


### PR DESCRIPTION
closes #164 

This PR fixes the issue reported in #164. The problem was that when filtering the anndata object it would result in an anndata object with potentially 0 rows. This PR checks whether the anndata object to be added to the metadata has 0 rows. If this is the case then the `adata` metadata is set to be `None`. Also if there is no table, adata will be none, but in addition `region_key` will also be `None`.

In addition to the implementation of @aeisenbarth this handles the case when a table is present, but there are no annotations for a given element.