### PR TITLE
Add safeguard when table is None

### DIFF
--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -163,8 +163,10 @@ class SpatialDataViewer:
                 "sdata": sdata,
                 "adata": sdata.table[
                     sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == original_name
-                ],
-                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"],
+                ]
+                if sdata.table
+                else None,
+                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"] if sdata.table else None,
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
                 "_current_cs": selected_cs,
@@ -206,8 +208,10 @@ class SpatialDataViewer:
             shape_type="polygon",
             metadata={
                 "sdata": sdata,
-                "adata": sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key],
-                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"],
+                "adata": sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key]
+                if sdata.table
+                else None,
+                "region_key": sdata.table.uns["spatialdata_attrs"]["region_key"] if sdata.table else None,
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
                 "_current_cs": selected_cs,
@@ -228,8 +232,10 @@ class SpatialDataViewer:
             affine=affine,
             metadata={
                 "sdata": sdata,
-                "adata": sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key],
-                "region_key": sdata.table.uns["spatialdata_attrs"]["instance_key"],
+                "adata": sdata.table[sdata.table.obs[sdata.table.uns["spatialdata_attrs"]["region_key"]] == key]
+                if sdata.table
+                else None,
+                "region_key": sdata.table.uns["spatialdata_attrs"]["instance_key"] if sdata.table else None,
                 "name": original_name,
                 "_active_in_cs": {selected_cs},
                 "_current_cs": selected_cs,


### PR DESCRIPTION
Instantiation of `SpatialData` does not create a table, implying that the table is optional.

A SpatialData object with just (visual) elements but no annotations can still be of interest for viewing in napari-spatialdata, however it tried to load annotations without checking whether a table exists.