### PR TITLE
remove npe related parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ pip install napari-spatialdata
 
 You can find more details on this in the [installation instructions](https://spatialdata.scverse.org/en/latest/installation.html).
 
+## Using napari-spatialdata as default zarr reader
+
+If you would like to use the plugin as the default zarr reader, in napari please go to `File` -> `Preferences`
+-> `Plugins` and follow the instructions under `File extension readers`.
+
 ## Development Version
 
 You can install `napari-spatialdata` from Github with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     matplotlib
     napari
     napari-matplotlib
-    napari-plugin-engine
     numba
     numpy
     packaging

--- a/src/napari_spatialdata/_reader.py
+++ b/src/napari_spatialdata/_reader.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Callable
 
 from loguru import logger
-from napari_plugin_engine import napari_hook_implementation
 from spatialdata import SpatialData
 
 from napari_spatialdata import Interactive
@@ -11,7 +10,6 @@ from napari_spatialdata import Interactive
 readable_extensions = (".zarr",)
 
 
-@napari_hook_implementation
 def get_reader(path: str) -> Callable[..., list[tuple[None]]] | None:
     """Napari hook specification that start the napari-spatialdata plugin with the given path."""
     # if we know we cannot read the file, we immediately return None.


### PR DESCRIPTION
This PR resolves the comment of @psobolewskiPhD in #185. Specifically it removes those parts of the code related to `npe` and adds instructions in the readme to allow users to use `napari-spatialdata` as the default `.zarr` extension reader. 