### PR TITLE
Avoid exception when registering shortcut

### DIFF
--- a/src/napari_spatialdata/_model.py
+++ b/src/napari_spatialdata/_model.py
@@ -23,7 +23,7 @@ class ImageModel:
     _adata: Optional[AnnData] = field(init=False, default=None, repr=True)
     _spatial_key: str = field(default=Key.obsm.spatial, repr=False)
     _adata_layer: Optional[str] = field(init=False, default=None, repr=False)
-    _label_key: Optional[str] = field(default=None, repr=True)
+    _labels_key: Optional[str] = field(default=None, repr=True)
     _coordinates: Optional[NDArrayA] = field(init=False, default=None, repr=True)
     _points_coordinates: Optional[NDArrayA] = field(init=False, default=None, repr=True)
     _points_var: Optional[pd.Series] = field(init=False, default=None, repr=True)

--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -43,8 +43,8 @@ class SpatialDataViewer(QObject):
         self.viewer = viewer
         self.sdata = sdata
         self._layer_event_caches: dict[str, list[dict[str, Any]]] = {}
-        self.viewer.bind_key("Shift-L", self._inherit_metadata)
-        self.viewer.bind_key("Shift-E", self._save_to_sdata)
+        self.viewer.bind_key("Shift-L", self._inherit_metadata, overwrite=False)
+        self.viewer.bind_key("Shift-E", self._save_to_sdata, overwrite=False)
         self.viewer.layers.events.inserted.connect(self._on_layer_insert)
         self.viewer.layers.events.removed.connect(self._on_layer_removed)
 


### PR DESCRIPTION
Napari does not allow registering an existing shortcut.

This can occur when:
- Another plugin or Napari itself or the user has registered "Shift-L", "Shift-E" before opening napari-spatialdata
- The user opened and closes napari-spatialdata multiple times in the same Napari session

As a consequence, Napari raises an exception and all code after shortcut registration cannot be used anymore.

This PR adds the optional argument `override` to silence the error. If you prefer `override=True`, I can change that (should have the same effect on avoiding the error).