### PR TITLE
add color by in adata view

### DIFF
--- a/src/napari_spatialdata/_model.py
+++ b/src/napari_spatialdata/_model.py
@@ -26,6 +26,7 @@ class ImageModel:
     _instance_key: Optional[str] = field(default=None, repr=True)
     _points_coordinates: Optional[NDArrayA] = field(init=False, default=None, repr=True)
     _points_var: Optional[pd.Series] = field(init=False, default=None, repr=True)
+    _color_by: str = field(default="", repr=True, init=False)
     _scale: Optional[float] = field(init=False, default=None)
     _system_name: Optional[str] = field(default=None, repr=True)
 
@@ -44,6 +45,7 @@ class ImageModel:
             source=self,
             layer=Event,
             adata=Event,
+            color_by=Event,
         )
 
     def get_items(self, attr: str) -> Tuple[str, ...]:
@@ -178,6 +180,15 @@ class ImageModel:
             return str(key) + (f":{self.adata_layer}" if self.adata_layer is not None else ":X") + f":{self.layer}"
 
         return str(key) + (f":{self.layer}" if self.layer is not None else ":X")
+
+    @property
+    def color_by(self) -> str:
+        return self._color_by
+
+    @color_by.setter
+    def color_by(self, color_column: str) -> None:
+        self._color_by = color_column
+        self.events.color_by()
 
     @property
     def table_names(self) -> Sequence[Optional[str]]:

--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -264,13 +264,9 @@ class QtAdataViewWidget(QWidget):
         self.layout().addWidget(self.obsm_widget)
         self.layout().addWidget(self.obsm_index_widget)
 
-        # gene
-        var_points = QLabel("Points:")
-        var_points.setToolTip("Gene names from points.")
-        self.var_points_widget = AListWidget(self.viewer, self.model, attr="points")
-
-        self.layout().addWidget(var_points)
-        self.layout().addWidget(self.var_points_widget)
+        # color by
+        self.color_by = QLabel("Colored by:")
+        self.layout().addWidget(self.color_by)
 
         # scalebar
         colorbar = CBarWidget(model=self.model)
@@ -280,6 +276,7 @@ class QtAdataViewWidget(QWidget):
         self.viewer.layers.selection.events.active.connect(self.slider._onLayerChange)
 
         self.model.events.adata.connect(self._on_layer_update)
+        self.model.events.color_by.connect(self._change_color_by)
 
     def _on_layer_update(self, event: Optional[Any] = None) -> None:
         """When the model updates the selected layer, update the relevant widgets."""
@@ -299,7 +296,6 @@ class QtAdataViewWidget(QWidget):
         self.obs_widget._onChange()
         self.var_widget._onChange()
         self.obsm_widget._onChange()
-        self.var_points_widget._onChange()
 
     def _select_layer(self) -> None:
         """Napari layers."""
@@ -312,7 +308,7 @@ class QtAdataViewWidget(QWidget):
                 self.obs_widget.clear()
                 self.var_widget.clear()
                 self.obsm_widget.clear()
-                self.var_points_widget.clear()
+                self.color_by.clear()
             return
 
         if layer is not None and "adata" in layer.metadata:
@@ -370,7 +366,6 @@ class QtAdataViewWidget(QWidget):
             self.obs_widget._onChange()
             self.var_widget._onChange()
             self.obsm_widget._onChange()
-            self.var_points_widget._onChange()
         else:
             return
 
@@ -388,6 +383,9 @@ class QtAdataViewWidget(QWidget):
             return table_names  # type: ignore[no-any-return]
 
         return None
+
+    def _change_color_by(self) -> None:
+        self.color_by.setText(f"Color by: {self.model.color_by}")
 
     @property
     def viewer(self) -> napari.Viewer:

--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -63,8 +63,8 @@ class SpatialDataViewer(QObject):
 
     def _on_layer_removed(self, event: Event) -> None:
         layer = event.value
-        if layer_name := layer.metadata.get("name"):
-            del self._layer_event_caches[layer_name]
+        if layer.metadata.get("name"):
+            del self._layer_event_caches[layer.name]
             self.layer_names.remove(layer.name)
 
     def _validate_name(self, event: Event) -> None:

--- a/src/napari_spatialdata/_widgets.py
+++ b/src/napari_spatialdata/_widgets.py
@@ -135,18 +135,13 @@ class AListWidget(ListWidget):
             else:
                 properties = self._get_points_properties(vec, key=item, layer=self.model.layer)
 
+                self.model.color_by = "" if self.model.system_name is None else item
                 if isinstance(self.model.layer, (Points, Shapes)):
-                    self.model.layer.name = (
-                        "" if self.model.system_name is None else self.model.layer.name + ":"
-                    ) + item
                     self.model.layer.text = None  # needed because of the text-feature order of updates
                     self.model.layer.features = properties.get("features", None)
                     self.model.layer.face_color = properties["face_color"]
                     self.model.layer.text = properties["text"]
                 elif isinstance(self.model.layer, Labels):
-                    self.model.layer.name = (
-                        "" if self.model.system_name is None else self.model.layer.name + ":"
-                    ) + item
                     self.model.layer.color = properties["color"]
                     self.model.layer.properties = properties.get("properties", None)
                 else:


### PR DESCRIPTION
closes #203

This issue removes the points in `QtAdataViewWidget` and replaces it by a `QLabel` indicating by which column a layer is being colored. Furthermore the construct of `:column_name` is not added anymore to the layer name. As a result the layer name is not changed when running any operation. 

Furthermore, because of this the removal of elements after coloring operations have been performed is fixed. Previously this would return an error due to the layer name having changed.