### PR TITLE
adjust to join_spatialelement

### DIFF
--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from spatialdata import join_sdata_spatialelement_table
+from spatialdata import join_spatialelement_table
 
 from napari_spatialdata._model import DataModel
 from napari_spatialdata._scatterwidgets import AxisWidgets, MatplotlibWidget
@@ -119,7 +119,9 @@ class QtAdataScatterWidget(QWidget):
 
         if sdata := layer.metadata.get("sdata"):
             element_name = layer.metadata.get("name")
-            _, table = join_sdata_spatialelement_table(sdata, element_name, table_name, "left")
+            _, table = join_spatialelement_table(
+                sdata=sdata, spatial_element_names=element_name, table_name=table_name, how="left"
+            )
             layer.metadata["adata"] = table
 
         if layer is not None and "adata" in layer.metadata:
@@ -351,7 +353,9 @@ class QtAdataViewWidget(QWidget):
         if sdata := layer.metadata.get("sdata"):
             element_name = layer.metadata.get("name")
             how = "left" if isinstance(layer, Labels) else "inner"
-            _, table = join_sdata_spatialelement_table(sdata, element_name, table_name, how)
+            _, table = join_spatialelement_table(
+                sdata=sdata, spatial_element_names=element_name, table_name=table_name, how=how
+            )
             layer.metadata["adata"] = table
 
         if layer is not None and "adata" in layer.metadata:

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -27,7 +27,7 @@ from pandas.core.dtypes.common import (
 from scipy.sparse import issparse, spmatrix
 from scipy.spatial import KDTree
 from spatial_image import SpatialImage
-from spatialdata import SpatialData, get_extent, join_sdata_spatialelement_table
+from spatialdata import SpatialData, get_extent, join_spatialelement_table
 from spatialdata.models import SpatialElement, get_axes_names
 from spatialdata.transformations import get_transformation
 
@@ -383,7 +383,9 @@ def _get_init_metadata_adata(sdata: SpatialData, table_name: str, element_name: 
     """
     if not table_name:
         return None
-    _, adata = join_sdata_spatialelement_table(sdata, element_name, table_name, how="left", match_rows="left")
+    _, adata = join_spatialelement_table(
+        sdata=sdata, spatial_element_names=element_name, table_name=table_name, how="left", match_rows="left"
+    )
 
     if adata.shape[0] == 0:
         return None


### PR DESCRIPTION
In spatialdata we adjusted the function `join_sdata_spatialelement_table`. The function is now called `join_spatialelement_table` and works both inside and outside the `SpatialData` object. I adjusted the code here to reflect this.