### PR TITLE
Avoid exception when key binding collides with existing

### DIFF
--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -49,8 +49,8 @@ class SpatialDataViewer(QObject):
         self.viewer = viewer
         self.sdata = sdata
         self._layer_event_caches: dict[str, list[dict[str, Any]]] = {}
-        self.viewer.bind_key("Shift-L", self._inherit_metadata, overwrite=False)
-        self.viewer.bind_key("Shift-E", self._save_to_sdata, overwrite=False)
+        self.viewer.bind_key("Shift-L", self._inherit_metadata, overwrite=True)
+        self.viewer.bind_key("Shift-E", self._save_to_sdata, overwrite=True)
         self.viewer.layers.events.inserted.connect(self._on_layer_insert)
         self._active_layer_table_names = None
         self.viewer.layers.events.removed.connect(self._on_layer_removed)


### PR DESCRIPTION
This avoids raising an error on key binding collision when napari-spatialdata is opened/closed multiple times (or the keymap has bin registered by another plugin).

Sorry, my previous fix was in the wrong direction and too permissive. There is no way to "register only if not yet in use", but one can only force override any previous shortcut. Without `override=True`, the error is raised.