### PR TITLE
fix: use `current_point` instead of `displayed` to fix contrast calculation

### DIFF
--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -305,8 +305,7 @@ class QtAdataViewWidget(QWidget):
 
         current_point = list(event.value)
         displayed = self._viewer.dims.displayed
-
-        for i, (lo_size, hi_size, cord) in enumerate(zip(layer.data[-1].shape, layer.data[0].shape, displayed)):
+        for i, (lo_size, hi_size, cord) in enumerate(zip(layer.data[-1].shape, layer.data[0].shape, current_point)):
             if i in displayed:
                 current_point[i] = slice(None)
             else:


### PR DESCRIPTION
It looks like I did not focus enough on #276 and accidentally left `displayed` instead `current_point` in the code. 
It works, when I open PR as image on which I worked was loaded as RGB. Now it is loaded as 3 channels and the current code ends with an exception. 