### PR TITLE
docs: Fix installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,9 @@ This repository contains a napari plugin for interactively exploring and annotat
 
 You can install `napari-spatialdata` via [pip]:
 
-    pip install napari-spatialdata[extra]
+    pip install napari-spatialdata[all]
 
-The `extra` command will install the qt bindings `PyQt5`.
-
-Note: if you have an M1/M2 Mac then you may get an error when installing `PyQt5` via `pip`. A solution is to first install `napari` via conda (which will correctly install `PyQt5`), using
-
-```
-mamba install -c conda-forge napari pyqt
-```
-
-and then install `napari-spatialdata` via `pip`, but without the `extra` option:
-
-```
-pip install napari-spatialdata
-```
+The `all` command will install the qt bindings `PyQt5`.
 
 You can find more details on this in the [installation instructions](https://spatialdata.scverse.org/en/latest/installation.html).
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ pre =
     spatialdata>=0.1.0-pre0
 
 all =
-    PyQt5
+    napari[pyqt5]
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Since a long time, the PyQt5 wheels have been available on PyPi. This part of instruction is no longer relevant. 

Also specify PyQt5 dependency using `napari[pyqt5]` to enforce version constraints from napari (to not install incompatible version of `PyQt5`)