### PR TITLE
miant: Add depenabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci(dependabot):"
+    labels:
+      - "maintenance"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR adds dependabot configuration to automatically bump versions of used actions and prevent failure of CI because of using outdated actions. 

It is scheduled to be monthly to avoid to often PR.