### PR TITLE
Modernize release workflow use most recent tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,39 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    paths:
+      - .github/workflows/make_release.yml
 
 jobs:
   release:
     # requires that you have put your twine API key in your
     # github secrets (see readme for details)
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'tags')
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: hynek/build-and-inspect-python-package@v2
+      - name: determine tag
+        run: echo "tag=${GITHUB_REF/refs\/tags\/v/}" >> "$GITHUB_ENV"
+      - name: Create Release
+        uses: "softprops/action-gh-release@v2"
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine build
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
-        run: |
-          git tag
-          python -m build .
-          twine upload dist/*
+          tag_name: ${{ github.ref }}
+          name: ${{ env.tag }}
+          draft: false
+          prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
+          target_commitish: ${{ github.sha }}
+          files: |
+            dist/*
+      - name: Publish PyPI Package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TWINE_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     paths:
-      - .github/workflows/make_release.yml
+      - .github/workflows/release.yml
 
 jobs:
   release:


### PR DESCRIPTION
This PR is modernizing release workflow (and allowing for future switch into trusted publishers) to use most recent tools best practices. 

The main missing thing is to cut information from the changelog file and provide it as a body. 