### PR TITLE
Fix deploy by read dist path form output of previous steep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hynek/build-and-inspect-python-package@v2
+        id: build_dist
       - name: determine tag
         run: echo "tag=${GITHUB_REF/refs\/tags\/v/}" >> "$GITHUB_ENV"
       - name: Create Release
@@ -30,10 +31,10 @@ jobs:
           draft: false
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
           target_commitish: ${{ github.sha }}
-          files: |
-            dist/*
+          files: ${{ steps.build_dist.outputs.dist }}
       - name: Publish PyPI Package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TWINE_API_KEY }}
+          packages-dir: ${{ steps.build_dist.outputs.dist }}


### PR DESCRIPTION
In #291 I wrongly assume that artifacts will be available in `dist` directory (like it was in the past before I split my deploy pipeline on multiple jobs).  

This PR fix deploy by use output of previous steep documented here https://github.com/hynek/build-and-inspect-python-package?tab=readme-ov-file#outputs

It should work now. 