### PR TITLE
Fix deploy by using local directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           draft: false
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
           target_commitish: ${{ github.sha }}
-          files: ${{ steps.build_dist.outputs.dist }}
+          files: ${{ steps.build_dist.outputs.dist }}/*
       - name: Publish PyPI Package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
           echo "dist=${{ steps.build_dist.outputs.dist }}"
           ls -l ${{ steps.build_dist.outputs.dist }}
           mkdir -p dist
-          cp -r ${{ steps.build_dist.outputs.dist }}/* ./dist/
+          cp ${{ steps.build_dist.outputs.dist }}/*.whl ./dist/
+          cp ${{ steps.build_dist.outputs.dist }}/*.gz ./dist/
 
       - name: Create Release
         uses: "softprops/action-gh-release@v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
           set -x
           echo "dist=${{ steps.build_dist.outputs.dist }}"
           ls -l ${{ steps.build_dist.outputs.dist }}
+          mkdir -p dist
+          cp -r ${{ steps.build_dist.outputs.dist }}/* ./dist/
 
       - name: Create Release
         uses: "softprops/action-gh-release@v2"
@@ -39,10 +41,9 @@ jobs:
           draft: false
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
           target_commitish: ${{ github.sha }}
-          files: ${{ steps.build_dist.outputs.dist }}/*
+          files: dist/*
       - name: Publish PyPI Package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TWINE_API_KEY }}
-          packages-dir: ${{ steps.build_dist.outputs.dist }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
       - name: determine tag
         run: echo "tag=${GITHUB_REF/refs\/tags\/v/}" >> "$GITHUB_ENV"
       - name: debug dist
-        run: set -x
+        run: |
+          set -x
           echo "dist=${{ steps.build_dist.outputs.dist }}"
           ls -l ${{ steps.build_dist.outputs.dist }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: hynek/build-and-inspect-python-package@v2
         id: build_dist
       - name: determine tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
         id: build_dist
       - name: determine tag
         run: echo "tag=${GITHUB_REF/refs\/tags\/v/}" >> "$GITHUB_ENV"
+      - name: debug dist
+        run: set -x
+          echo "dist=${{ steps.build_dist.outputs.dist }}"
+          ls -l ${{ steps.build_dist.outputs.dist }}
+
       - name: Create Release
         uses: "softprops/action-gh-release@v2"
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
The `pypa/gh-action-pypi-publish@release` action is a docker-based action and is mounting only part of directories of parent machines. Especially, do not mount `/tmp/` directory where `hynek/build-and-inspect-python-package` is storing the output of build. 

This PR copy output of `hynek/build-and-inspect-python-package` to local directory `dist` to use it in next steeps. 