### PR TITLE
Fix paths in benchmarks

### DIFF
--- a/.github/BENCHMARK_FAIL_TEMPLATE.md
+++ b/.github/BENCHMARK_FAIL_TEMPLATE.md
@@ -8,6 +8,6 @@ The {{ workflow }} workflow failed on {{ date | date("YYYY-MM-DD HH:mm") }} UTC
 The most recent failing benchmark was on {{ env.PLATFORM }} py{{ env.PYTHON }} {{ env.BACKEND }}
 with commit: {{ sha }}
 
-Full run: https://github.com/napari/napari/actions/runs/{{ env.RUN_ID }}
+Full run: https://github.com/scverse/napari-spatialdata/actions/runs/{{ env.RUN_ID }}
 
 (This post will be updated if another test fails, as long as this issue remains open.)

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup asv
         run: python -m pip install "asv[virtualenv]"
         env:
-          PIP_CONSTRAINT: resources/constraints/benchmark.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/benchmarks/benchmark.txt
 
       - uses: octokit/request-action@v2.x
         id: latest_release


### PR DESCRIPTION
In #289 I have missed one constraint's path that lead to failure reported in #296

This PR fixes it and improves the report template. 

Closes #296