### PR TITLE
Minimum 3.9.2, testing against 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest] # [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, "3.10"] # [3.8, 3.9, "3.10"]
+        python-version: ["3.9", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ write_to = "src/napari_spatialdata/_version.py"
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py39']
 include = '\.pyi?$'
 exclude = '''
 (
@@ -38,7 +38,7 @@ exclude = [
     "setup.py",
 ]
 line-length = 120
-target-version = "py38"
+target-version = "py39"
 [tool.ruff.lint]
 ignore = [
     # Do not assign a lambda expression, use a def -> lambda expression assignments are convenient

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.9.2
 setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =

--- a/src/napari_spatialdata/_model.py
+++ b/src/napari_spatialdata/_model.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence, Tuple, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -19,19 +22,19 @@ class DataModel:
     """Model which holds the data for interactive visualization."""
 
     events: EmitterGroup = field(init=False, default=None, repr=True)
-    _table_names: Sequence[Optional[str]] = field(default_factory=list, init=False)
-    _active_table_name: Optional[str] = field(default=None, init=False, repr=True)
+    _table_names: Sequence[str | None] = field(default_factory=list, init=False)
+    _active_table_name: str | None = field(default=None, init=False, repr=True)
     _layer: Layer = field(init=False, default=None, repr=True)
-    _adata: Optional[AnnData] = field(init=False, default=None, repr=True)
-    _adata_layer: Optional[str] = field(init=False, default=None, repr=False)
-    _region_key: Optional[str] = field(default=None, repr=True)
-    _instance_key: Optional[str] = field(default=None, repr=True)
+    _adata: AnnData | None = field(init=False, default=None, repr=True)
+    _adata_layer: str | None = field(init=False, default=None, repr=False)
+    _region_key: str | None = field(default=None, repr=True)
+    _instance_key: str | None = field(default=None, repr=True)
     _color_by: str = field(default="", repr=True, init=False)
-    _system_name: Optional[str] = field(default=None, repr=True)
+    _system_name: str | None = field(default=None, repr=True)
 
-    _scale_key: Optional[str] = field(init=False, default="tissue_hires_scalef")  # TODO(giovp): use constants for these
+    _scale_key: str | None = field(init=False, default="tissue_hires_scalef")  # TODO(giovp): use constants for these
 
-    _palette: Optional[str] = field(init=False, default=None, repr=False)
+    _palette: str | None = field(init=False, default=None, repr=False)
     _cmap: str = field(init=False, default="viridis", repr=False)
     _symbol: str = field(init=False, default=Symbol.DISC, repr=False)
 
@@ -45,7 +48,7 @@ class DataModel:
             color_by=Event,
         )
 
-    def get_items(self, attr: str) -> Optional[Tuple[str, ...]]:
+    def get_items(self, attr: str) -> tuple[str, ...] | None:
         """
         Return valid keys for an attribute.
 
@@ -68,9 +71,7 @@ class DataModel:
         return None
 
     @_ensure_dense_vector
-    def get_obs(
-        self, name: str, **_: Any
-    ) -> Tuple[Optional[Union[pd.Series, NDArrayA]], str]:  # TODO(giovp): fix docstring
+    def get_obs(self, name: str, **_: Any) -> tuple[pd.Series | NDArrayA | None, str]:  # TODO(giovp): fix docstring
         """
         Return an observation.
 
@@ -94,7 +95,7 @@ class DataModel:
         return obs_column, self._format_key(name)
 
     @_ensure_dense_vector
-    def get_columns_df(self, name: Union[str, int], **_: Any) -> Tuple[Optional[NDArrayA], str]:
+    def get_columns_df(self, name: str | int, **_: Any) -> tuple[NDArrayA | None, str]:
         """
         Return a column of the dataframe of the SpatialElement.
 
@@ -112,7 +113,7 @@ class DataModel:
         return self.layer.metadata["_columns_df"][name], self._format_key(name)
 
     @_ensure_dense_vector
-    def get_var(self, name: Union[str, int], **_: Any) -> Tuple[Optional[NDArrayA], str]:  # TODO(giovp): fix docstring
+    def get_var(self, name: str | int, **_: Any) -> tuple[NDArrayA | None, str]:  # TODO(giovp): fix docstring
         """
         Return a column in anndata.var_names.
 
@@ -134,7 +135,7 @@ class DataModel:
         return self.adata._get_X(layer=self.adata_layer)[ix], self._format_key(name, adata_layer=True)
 
     @_ensure_dense_vector
-    def get_obsm(self, name: str, index: Union[int, str] = 0) -> Tuple[Optional[NDArrayA], str]:
+    def get_obsm(self, name: str, index: int | str = 0) -> tuple[NDArrayA | None, str]:
         """
         Return a vector from :attr:`anndata.AnnData.obsm`.
 
@@ -174,9 +175,7 @@ class DataModel:
 
         return (res if res.ndim == 1 else res[:, index]), pretty_name
 
-    def _format_key(
-        self, key: Union[str, int], index: Optional[Union[int, str]] = None, adata_layer: bool = False
-    ) -> str:
+    def _format_key(self, key: str | int, index: int | str | None = None, adata_layer: bool = False) -> str:
         if index is not None:
             return str(key) + f":{index}:{self.layer}"
         if adata_layer:
@@ -195,31 +194,31 @@ class DataModel:
         self.events.color_by()
 
     @property
-    def table_names(self) -> Sequence[Optional[str]]:
+    def table_names(self) -> Sequence[str | None]:
         """The table names annotating the current active napari layer, if any."""
         return self._table_names
 
     @table_names.setter
-    def table_names(self, table_names: Sequence[Optional[str]]) -> None:
+    def table_names(self, table_names: Sequence[str | None]) -> None:
         self._table_names = table_names
 
     @property
-    def layer(self) -> Optional[Layer]:  # noqa: D102
+    def layer(self) -> Layer | None:  # noqa: D102
         """The current active napari layer."""
         return self._layer
 
     @layer.setter
-    def layer(self, layer: Optional[Layer]) -> None:
+    def layer(self, layer: Layer | None) -> None:
         self._layer = layer
         self.events.layer()
 
     @property
-    def active_table_name(self) -> Optional[str]:
+    def active_table_name(self) -> str | None:
         """The table name currently active in the widget."""
         return self._active_table_name
 
     @active_table_name.setter
-    def active_table_name(self, active_table_name: Optional[str]) -> None:
+    def active_table_name(self, active_table_name: str | None) -> None:
         self._active_table_name = active_table_name
 
     @property
@@ -233,7 +232,7 @@ class DataModel:
         self.events.adata()
 
     @property
-    def adata_layer(self) -> Optional[str]:  # noqa: D102
+    def adata_layer(self) -> str | None:  # noqa: D102
         """The current anndata layer."""
         return self._adata_layer
 
@@ -242,7 +241,7 @@ class DataModel:
         self._adata_layer = adata_layer
 
     @property
-    def region_key(self) -> Optional[str]:  # noqa: D102
+    def region_key(self) -> str | None:  # noqa: D102
         """The region key of the currently active table in the widget."""
         if self.adata is not None:
             _, region_key, _ = get_table_keys(self.adata)
@@ -251,7 +250,7 @@ class DataModel:
         return None
 
     @property
-    def instance_key(self) -> Optional[str]:  # noqa: D102
+    def instance_key(self) -> str | None:  # noqa: D102
         """The instance key of the currently active table in the widget."""
         if self.adata is not None:
             _, _, instance_key = get_table_keys(self.adata)
@@ -260,7 +259,7 @@ class DataModel:
         return None
 
     @property
-    def palette(self) -> Optional[str]:  # noqa: D102
+    def palette(self) -> str | None:  # noqa: D102
         """The palette from which to draw the colors."""
         return self._palette
 
@@ -286,7 +285,7 @@ class DataModel:
         self._symbol = symbol
 
     @property
-    def scale_key(self) -> Optional[str]:  # noqa: D102
+    def scale_key(self) -> str | None:  # noqa: D102
         return self._scale_key
 
     @scale_key.setter
@@ -294,7 +293,7 @@ class DataModel:
         self._scale_key = scale_key
 
     @property
-    def system_name(self) -> Optional[str]:  # noqa: D102
+    def system_name(self) -> str | None:  # noqa: D102
         """The layer name."""
         return self._system_name
 

--- a/src/napari_spatialdata/_scatterwidgets.py
+++ b/src/napari_spatialdata/_scatterwidgets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 import matplotlib as plt
 import numpy as np

--- a/src/napari_spatialdata/_sdata_widgets.py
+++ b/src/napari_spatialdata/_sdata_widgets.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import shapely
 from napari.utils.events import EventedList

--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import napari
 import numpy as np

--- a/src/napari_spatialdata/_widgets.py
+++ b/src/napari_spatialdata/_widgets.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections import defaultdict
+from collections.abc import Iterable, Sequence
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Any, Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import napari

--- a/src/napari_spatialdata/constants/_utils.py
+++ b/src/napari_spatialdata/constants/_utils.py
@@ -1,10 +1,10 @@
 from abc import ABC, ABCMeta
 from enum import Enum, EnumMeta
 from functools import wraps
-from typing import Any, Callable, Dict, Tuple, Type
+from typing import Any, Callable
 
 
-def _pretty_raise_enum(cls: Type["ModeEnum"], fun: Callable[..., Any]) -> Callable[..., Any]:
+def _pretty_raise_enum(cls: type["ModeEnum"], fun: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(fun)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
@@ -53,7 +53,7 @@ class ABCEnumMeta(EnumMeta, ABCMeta):
             raise TypeError(f"Can't instantiate class `{cls.__name__}` without `__error_format__` class attribute.")
         return super().__call__(*args, **kw)  # type: ignore[no-any-return]
 
-    def __new__(cls, clsname: str, bases: Tuple[EnumMeta, ...], namespace: Dict[str, Any]) -> "ABCEnumMeta":
+    def __new__(cls, clsname: str, bases: tuple[EnumMeta, ...], namespace: dict[str, Any]) -> "ABCEnumMeta":
         res: ABCEnumMeta = super().__new__(cls, clsname, bases, namespace)  # type: ignore[arg-type]
         res.__new__ = _pretty_raise_enum(res, res.__new__)  # type: ignore[method-assign,arg-type]
         return res

--- a/src/napari_spatialdata/utils/_categoricals_utils.py
+++ b/src/napari_spatialdata/utils/_categoricals_utils.py
@@ -1,5 +1,7 @@
-import collections.abc as cabc
-from typing import Any, Dict, List, Optional, Sequence, Union
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -230,7 +232,7 @@ def _validate_palette(adata: AnnData, key: str) -> None:
     # and updates the color list in adata.uns[f'{key}_colors'] if needed.
     # Not only valid matplotlib colors are checked but also if the color name
     # is a valid R color name, in which case it will be translated to a valid name.
-    _palette: List[str] = []
+    _palette: list[str] = []
     color_key = f"{key}_colors"
 
     for color in adata.uns[color_key]:
@@ -255,9 +257,9 @@ def _validate_palette(adata: AnnData, key: str) -> None:
 
 def _set_colors_for_categorical_obs(
     adata: AnnData,
-    categories: Sequence[Union[str, int]],
+    categories: Sequence[str | int],
     value_to_plot: str,
-    palette: Union[str, Sequence[str], Cycler],
+    palette: str | Sequence[str] | Cycler,
 ) -> None:
     """
     Set the adata.uns[value_to_plot + '_colors'] according to the given palette.
@@ -283,12 +285,12 @@ def _set_colors_for_categorical_obs(
         # this creates a palette from a colormap. E.g. 'Accent, Dark2, tab20'
         cmap = pl.get_cmap(palette)
         colors_list = [to_hex(x) for x in cmap(np.linspace(0, 1, len(categories)))]
-    elif isinstance(palette, cabc.Mapping):
+    elif isinstance(palette, Mapping):
         colors_list = [to_hex(palette[k], keep_alpha=True) for k in categories]
     else:
         # check if palette is a list and convert it to a cycler, thus
         # it doesnt matter if the list is shorter than the categories length:
-        if isinstance(palette, cabc.Sequence):
+        if isinstance(palette, Sequence):
             if len(palette) < len(categories):
                 logger.warning(
                     "Length of palette colors is smaller than the number of "
@@ -325,7 +327,7 @@ def _set_colors_for_categorical_obs(
 
 
 def _set_default_colors_for_categorical_obs(
-    adata: AnnData, categories: Sequence[Union[str, int]], value_to_plot: str
+    adata: AnnData, categories: Sequence[str | int], value_to_plot: str
 ) -> None:
     """
     Set the adata.uns[value_to_plot + '_colors'] using default color palettes.
@@ -369,7 +371,7 @@ def _set_default_colors_for_categorical_obs(
 
 
 def add_colors_for_categorical_sample_annotation(
-    adata: AnnData, key: str, vec: pd.Series, palette: Optional[List[str]] = None, force_update_colors: bool = False
+    adata: AnnData, key: str, vec: pd.Series, palette: list[str] | None = None, force_update_colors: bool = False
 ) -> None:
     """Add colors for categorical annotation.
 
@@ -403,15 +405,15 @@ def add_colors_for_categorical_sample_annotation(
 def _add_categorical_legend(
     ax: Axes,
     color_source_vector: pd.Series,
-    palette: Dict[str, str],
+    palette: dict[str, str],
     legend_loc: str = "right margin",
     legend_fontweight: str = "bold",
-    legend_fontsize: Optional[float] = None,
-    legend_fontoutline: Optional[float] = None,
+    legend_fontsize: float | None = None,
+    legend_fontoutline: float | None = None,
     multi_panel: bool = False,
     na_color: str = "lightgray",
     na_in_legend: bool = True,
-    scatter_array: Optional[Any] = None,  # added defaults compared to scanpy
+    scatter_array: Any | None = None,  # added defaults compared to scanpy
 ) -> None:
     """Add a legend to the passed Axes."""
     if na_in_legend and pd.isnull(color_source_vector).any():

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from functools import wraps
 from random import randint
-from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import numpy as np
 import packaging.version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from abc import ABC, ABCMeta
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable
 
 import napari
 import numpy as np
@@ -116,13 +118,13 @@ def labels():
     return blobs
 
 
-def _get_blobs_galaxy() -> Tuple[NDArrayA, NDArrayA]:
+def _get_blobs_galaxy() -> tuple[NDArrayA, NDArrayA]:
     blobs = data.binary_blobs(rng=SEED)
     blobs = ndi.label(blobs)[0]
     return blobs, data.hubble_deep_field()[: blobs.shape[0], : blobs.shape[0]]
 
 
-def generate_adata(n_var: int, obs: pd.DataFrame, obsm: Dict[Any, Any], uns: Dict[Any, Any]) -> AnnData:
+def generate_adata(n_var: int, obs: pd.DataFrame, obsm: dict[Any, Any], uns: dict[Any, Any]) -> AnnData:
     rng = np.random.default_rng(SEED)
     return AnnData(
         rng.normal(size=(obs.shape[0], n_var)),
@@ -145,7 +147,7 @@ class PlotTesterMeta(ABCMeta):
 # but for some reason, pytest erases the metaclass info
 class PlotTester(ABC):
     @classmethod
-    def compare(cls, basename: str, tolerance: Optional[float] = None):
+    def compare(cls, basename: str, tolerance: float | None = None):
         ACTUAL.mkdir(parents=True, exist_ok=True)
         out_path = ACTUAL / f"{basename}.png"
 
@@ -161,7 +163,7 @@ class PlotTester(ABC):
         assert res is None, res
 
 
-def _decorate(fn: Callable, clsname: str, name: Optional[str] = None) -> Callable:
+def _decorate(fn: Callable, clsname: str, name: str | None = None) -> Callable:
     @wraps(fn)
     def save_and_compare(self, *args, **kwargs):
         fn(self, *args, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 import pytest
@@ -54,7 +54,7 @@ def test_position_cluster_labels(adata_labels: AnnData):
 
 
 @pytest.mark.parametrize("tri_coord", [[[0, 10, 20], [30, 40, 50]]])
-def test_points_inside_triangles(adata_shapes: AnnData, tri_coord: List[List[int]]):
+def test_points_inside_triangles(adata_shapes: AnnData, tri_coord: list[list[int]]):
     from napari_spatialdata._model import DataModel
 
     coord1, coord2 = tri_coord


### PR DESCRIPTION
While debugging some code against `python` 3.9, I noticed how using `python` 3.9.0 or `3.9.1` systematically leads to these bugs https://github.com/dask/distributed/issues/7956.

Generally one would install a later patch version, but in this PR I add the constraint explicitly in the dependencies. 

Also I did some cleanup:
- black had `target-version = 'py38'`, I changed it to `py39`
- I am testing against 3.11 instead of 3.10. We could also test against 3.10 instead of only the min-max versions, at the cost of more CI time.