### PR TITLE
Fetch information about latest release informtion from proper repository

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -80,8 +80,8 @@ jobs:
         id: latest_release
         with:
           route: GET /repos/{owner}/{repo}/releases/latest
-          owner: napari
-          repo: napari
+          owner: scverse
+          repo: napari-spatialdata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
It is the next place where I miss that need to be updated when migrating from napari repository. 

closes #306