### PR TITLE
Add teardown steep for example benchamark

### DIFF
--- a/benchmarks/benchmark_qt_widget.py
+++ b/benchmarks/benchmark_qt_widget.py
@@ -17,3 +17,6 @@ class SdataWidgetSuite:
 
     def time_layer_added(self) -> None:
         self.viewer.add_layer(self.image)
+
+    def teardown(self) -> None:
+        self.viewer.close()


### PR DESCRIPTION
closes #308

I got pointed thatcurrent faliture of benchamarks may be resolved by teardown steep. 