### PR TITLE
Fix bug adata in model not being reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning][].
 
 ## [0.x.x] - 2024-xx-xx
 
+### Fixed
+
+- Bug table was not reset after an element without table was added #317
+
 ## [0.5.2] - 2024-08-16
 
 ### Minor

--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -137,9 +137,13 @@ class QtAdataScatterWidget(QWidget):
             )
             layer.metadata["adata"] = table
 
-        if layer is not None and "adata" in layer.metadata:
-            with self.model.events.adata.blocker():
-                self.model.adata = layer.metadata["adata"]
+        if layer is not None:
+            if "adata" in layer.metadata:
+                with self.model.events.adata.blocker():
+                    self.model.adata = layer.metadata["adata"]
+            else:
+                with self.model.events.adata.blocker():
+                    self.model.adata = None
 
         if self.model.adata.shape == (0, 0):
             return
@@ -186,8 +190,8 @@ class QtAdataScatterWidget(QWidget):
                 self.color_widget.clear()
             return
 
-        if layer is not None and "adata" in layer.metadata:
-            self.model.adata = layer.metadata["adata"]
+        if layer is not None:
+            self.model.adata = layer.metadata.get("adata", None)
 
     def screenshot(self) -> Any:
         return QImg2array(self.grab().toImage())
@@ -384,10 +388,11 @@ class QtAdataViewWidget(QWidget):
                 if isinstance(layer, (Points, Shapes)) and (cols_df := layer.metadata.get("_columns_df")) is not None:
                     self.dataframe_columns_widget.addItems(map(str, cols_df.columns))
                     self.model.system_name = layer.metadata.get("name", None)
+            self.model.adata = None
             return
 
-        if layer is not None and "adata" in layer.metadata:
-            self.model.adata = layer.metadata["adata"]
+        if layer is not None:
+            self.model.adata = layer.metadata.get("adata", None)
 
         if self.model.adata.shape == (0, 0):
             return
@@ -418,9 +423,13 @@ class QtAdataViewWidget(QWidget):
             )
             layer.metadata["adata"] = table
 
-        if layer is not None and "adata" in layer.metadata:
-            with self.model.events.adata.blocker():
-                self.model.adata = layer.metadata["adata"]
+        if layer is not None:
+            if "adata" in layer.metadata:
+                with self.model.events.adata.blocker():
+                    self.model.adata = layer.metadata["adata"]
+            else:
+                with self.model.events.adata.blocker():
+                    self.model.adata = None
 
         if self.model.adata.shape == (0, 0):
             return
@@ -440,10 +449,12 @@ class QtAdataViewWidget(QWidget):
             return
 
     def _get_adata_layer(self) -> Sequence[str | None]:
+        if self.model.adata is None:
+            return [None]
         adata_layers = list(self.model.adata.layers.keys())
-        if len(adata_layers):
-            return adata_layers
-        return [None]
+        if len(adata_layers) == 0:
+            return [None]
+        return adata_layers
 
     def _change_color_by(self) -> None:
         self.color_by.setText(f"Color by: {self.model.color_by}")

--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -17,6 +17,7 @@ from qtpy.QtCore import QObject, Signal
 from shapely import Polygon
 from spatialdata import get_element_annotators, get_element_instances
 from spatialdata._core.query.relational_query import _left_join_spatialelement_table
+from spatialdata._types import ArrayLike
 from spatialdata.models import PointsModel, ShapesModel, TableModel, force_2d, get_channels
 from spatialdata.transformations import Affine, Identity
 from spatialdata.transformations._utils import scale_radii
@@ -254,15 +255,13 @@ class SpatialDataViewer(QObject):
             for shape in layer_to_save._data_view.shapes
         ]
 
-        def _fix_coords(coords: np.ndarray) -> np.ndarray:
+        def _fix_coords(coords: ArrayLike) -> ArrayLike:
             remove_z = coords.shape[1] == 3
             first_index = 1 if remove_z else 0
             coords = coords[:, first_index::]
             return np.fliplr(coords)
 
         polygons: list[Polygon] = [Polygon(_fix_coords(p)) for p in coords]
-        # polygons: list[Polygon] = [Polygon(i) for i in _transform_coordinates(coords, f=lambda x: x[::-1])]
-        # polygons: list[Polygon] = [Polygon(i) for i in _transform_coordinates(layer_to_save.data, f=lambda x: x[::-1])]
         gdf = GeoDataFrame({"geometry": polygons})
 
         force_2d(gdf)

--- a/src/napari_spatialdata/_widgets.py
+++ b/src/napari_spatialdata/_widgets.py
@@ -227,7 +227,7 @@ class AListWidget(ListWidget):
                         f"The {vec_color_name} column must have unique values for the each {vec.name} level. Found:\n"
                         f"{unique_colors}"
                     )
-                color_dict = unique_colors.to_dict()["genes_color"]
+                color_dict = unique_colors.to_dict()[f"{vec.name}_color"]
 
         if self.model.instance_key is not None and self.model.instance_key == vec.index.name:
             merge_df = pd.merge(

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -419,7 +419,7 @@ def get_itemindex_by_text(
     return widget_item
 
 
-def _get_init_table_list(layer: Layer) -> Sequence[str | None] | None:
+def _get_init_table_list(layer: Layer | None) -> Sequence[str | None] | None:
     """
     Get the table names annotating the SpatialElement upon creating the napari layer.
 
@@ -432,6 +432,8 @@ def _get_init_table_list(layer: Layer) -> Sequence[str | None] | None:
     ------
     The list of table names annotating the SpatialElement if any.
     """
+    if layer is None:
+        return None
     table_names: Sequence[str | None] | None
     if table_names := layer.metadata.get("table_names"):
         return table_names  # type: ignore[no-any-return]


### PR DESCRIPTION
Fixes two bugs:
- there was a hardcoded `genes_color`, I fixed this
- if an element with a table was added and removed, the `mode.table` was not being reset, leading to inconsistent behavior

CC @melonora 