### PR TITLE
fix radii of transformed circles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.5.4] - 2024-xx-xx
+
+### Fixed
+
+- Bug wrong radii transformed circles (e.g. with Visium lowres)
+
 ## [0.5.3] - 2024-09-25
 
 ### Fixed

--- a/src/napari_spatialdata/_interactive.py
+++ b/src/napari_spatialdata/_interactive.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Any
 
 import napari
 from napari.utils.events import EventedList
+from spatialdata._types import ArrayLike
 
 from napari_spatialdata._sdata_widgets import SdataWidget
 from napari_spatialdata.utils._utils import (
-    NDArrayA,
     get_duplicate_element_names,
     get_elements_meta_mapping,
     get_itemindex_by_text,
@@ -97,6 +97,6 @@ class Interactive:
         """Run the napari application."""
         napari.run()
 
-    def screenshot(self) -> NDArrayA | Any:
+    def screenshot(self) -> ArrayLike | Any:
         """Take a screenshot of the viewer in its current state."""
         return self._viewer.screenshot(canvas_only=False)

--- a/src/napari_spatialdata/_model.py
+++ b/src/napari_spatialdata/_model.py
@@ -9,10 +9,11 @@ import pandas as pd
 from anndata import AnnData
 from napari.layers import Layer
 from napari.utils.events import EmitterGroup, Event
+from spatialdata._types import ArrayLike
 from spatialdata.models import get_table_keys
 
 from napari_spatialdata.constants._constants import Symbol
-from napari_spatialdata.utils._utils import NDArrayA, _ensure_dense_vector
+from napari_spatialdata.utils._utils import _ensure_dense_vector
 
 __all__ = ["DataModel"]
 
@@ -71,7 +72,7 @@ class DataModel:
         return None
 
     @_ensure_dense_vector
-    def get_obs(self, name: str, **_: Any) -> tuple[pd.Series | NDArrayA | None, str]:  # TODO(giovp): fix docstring
+    def get_obs(self, name: str, **_: Any) -> tuple[pd.Series | ArrayLike | None, str]:  # TODO(giovp): fix docstring
         """
         Return an observation.
 
@@ -95,7 +96,7 @@ class DataModel:
         return obs_column, self._format_key(name)
 
     @_ensure_dense_vector
-    def get_columns_df(self, name: str | int, **_: Any) -> tuple[NDArrayA | None, str]:
+    def get_columns_df(self, name: str | int, **_: Any) -> tuple[ArrayLike | None, str]:
         """
         Return a column of the dataframe of the SpatialElement.
 
@@ -113,7 +114,7 @@ class DataModel:
         return self.layer.metadata["_columns_df"][name], self._format_key(name)
 
     @_ensure_dense_vector
-    def get_var(self, name: str | int, **_: Any) -> tuple[NDArrayA | None, str]:  # TODO(giovp): fix docstring
+    def get_var(self, name: str | int, **_: Any) -> tuple[ArrayLike | None, str]:  # TODO(giovp): fix docstring
         """
         Return a column in anndata.var_names.
 
@@ -135,7 +136,7 @@ class DataModel:
         return self.adata._get_X(layer=self.adata_layer)[ix], self._format_key(name, adata_layer=True)
 
     @_ensure_dense_vector
-    def get_obsm(self, name: str, index: int | str = 0) -> tuple[NDArrayA | None, str]:
+    def get_obsm(self, name: str, index: int | str = 0) -> tuple[ArrayLike | None, str]:
         """
         Return a vector from :attr:`anndata.AnnData.obsm`.
 

--- a/src/napari_spatialdata/_scatterwidgets.py
+++ b/src/napari_spatialdata/_scatterwidgets.py
@@ -19,12 +19,13 @@ from napari_matplotlib.base import NapariMPLWidget
 from pandas.api.types import CategoricalDtype
 from qtpy import QtWidgets
 from qtpy.QtCore import Signal
+from spatialdata._types import ArrayLike
 
 from napari_spatialdata._model import DataModel
 from napari_spatialdata._widgets import AListWidget, ComponentWidget
 from napari_spatialdata.constants.config import POINT_SIZE_SCATTERPLOT_WIDGET
 from napari_spatialdata.utils._categoricals_utils import _add_categorical_legend
-from napari_spatialdata.utils._utils import NDArrayA, _get_categorical, _set_palette
+from napari_spatialdata.utils._utils import _get_categorical, _set_palette
 
 __all__ = [
     "MatplotlibWidget",
@@ -63,7 +64,7 @@ class SelectFromCollection:
         model: DataModel,
         ax: Axes,
         collection: Collection,
-        data: list[NDArrayA],
+        data: list[ArrayLike],
         alpha_other: float = 0.3,
         viewer: Viewer | None = None,
     ):
@@ -89,7 +90,7 @@ class SelectFromCollection:
 
         self.selector = LassoSelector(ax, onselect=self.onselect)
 
-        self.ind: NDArrayA | None = None
+        self.ind: ArrayLike | None = None
 
     def export(self, adata: AnnData) -> None:
         model_layer: Layer = self.model.layer
@@ -116,7 +117,7 @@ class SelectFromCollection:
         sdata[table_name].obs[obs_name] = self.exported_data
         show_info(f"Exported selected coordinates to obs in AnnData as: {obs_name}")
 
-    def onselect(self, verts: list[NDArrayA]) -> None:
+    def onselect(self, verts: list[ArrayLike]) -> None:
         self.path = Path(verts)
         self.ind = np.nonzero(self.path.contains_points(self.xys))[0]
 
@@ -140,7 +141,7 @@ class ScatterListWidget(AListWidget):
         AListWidget.__init__(self, None, model, attr, **kwargs)
         self.attrChanged.connect(self._onChange)
         self._color = color
-        self._data: NDArrayA | dict[str, Any] | None = None
+        self._data: ArrayLike | dict[str, Any] | None = None
         self.itemClicked.connect(lambda item: self._onOneClick((item.text(),)))
 
     def _onChange(self) -> None:
@@ -223,11 +224,11 @@ class ScatterListWidget(AListWidget):
         self._chosen = chosen if chosen is not None else None
 
     @property
-    def data(self) -> NDArrayA | dict[str, Any] | None:
+    def data(self) -> ArrayLike | dict[str, Any] | None:
         return self._data
 
     @data.setter
-    def data(self, data: NDArrayA | dict[str, Any]) -> None:
+    def data(self, data: ArrayLike | dict[str, Any]) -> None:
         self._data = data
 
 
@@ -251,9 +252,9 @@ class MatplotlibWidget(NapariMPLWidget):
 
     def _onClick(
         self,
-        x_data: NDArrayA | pd.Series,
-        y_data: NDArrayA | pd.Series,
-        color_data: NDArrayA | dict[str, NDArrayA | pd.Series | dict[str, str]],
+        x_data: ArrayLike | pd.Series,
+        y_data: ArrayLike | pd.Series,
+        color_data: ArrayLike | dict[str, ArrayLike | pd.Series | dict[str, str]],
         x_label: str | None,
         y_label: str | None,
         color_label: str | None,

--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -97,7 +97,7 @@ class QtAdataScatterWidget(QWidget):
             lambda: self.matplotlib_widget._onClick(
                 self.x_widget.widget.data,
                 self.y_widget.widget.data,
-                self.color_widget.widget.data,  # type:ignore[arg-type]
+                self.color_widget.widget.data,
                 self.x_widget.getFormattedLabel(),
                 self.y_widget.getFormattedLabel(),
                 self.color_widget.getFormattedLabel(),

--- a/src/napari_spatialdata/_viewer.py
+++ b/src/napari_spatialdata/_viewer.py
@@ -20,7 +20,6 @@ from spatialdata._core.query.relational_query import _left_join_spatialelement_t
 from spatialdata._types import ArrayLike
 from spatialdata.models import PointsModel, ShapesModel, TableModel, force_2d, get_channels
 from spatialdata.transformations import Affine, Identity
-from spatialdata.transformations._utils import scale_radii
 
 from napari_spatialdata._model import DataModel
 from napari_spatialdata.constants import config
@@ -741,8 +740,6 @@ class SpatialDataViewer(QObject):
             raise ValueError(f"Invalid affine shape: {affine.shape}")
         affine_transformation = Affine(affine, input_axes=axes, output_axes=axes)
 
-        new_radii = scale_radii(radii=radii, affine=affine_transformation, axes=axes)
-
         # the points size is the diameter, in "data pixels" of the current coordinate system, so we need to scale by
         # scale factor of the affine transformation. This scale factor is an approximation when the affine
         # transformation is anisotropic.
@@ -751,7 +748,7 @@ class SpatialDataViewer(QObject):
         modules = np.absolute(eigenvalues)
         scale_factor = np.mean(modules)
 
-        layer.size = 2 * new_radii / scale_factor
+        layer.size = 2 * radii * scale_factor
 
     def _affine_transform_layers(self, coordinate_system: str) -> None:
         for layer in self.viewer.layers:

--- a/src/napari_spatialdata/_widgets.py
+++ b/src/napari_spatialdata/_widgets.py
@@ -20,13 +20,14 @@ from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Qt, Signal
 from scanpy.plotting._utils import _set_colors_for_categorical_obs
 from sklearn.preprocessing import MinMaxScaler
+from spatialdata._types import ArrayLike
 from superqt import QRangeSlider
 from vispy import scene
 from vispy.color.colormap import Colormap, MatplotlibColormap
 from vispy.scene.widgets import ColorBarWidget
 
 from napari_spatialdata._model import DataModel
-from napari_spatialdata.utils._utils import NDArrayA, _min_max_norm, get_napari_version
+from napari_spatialdata.utils._utils import _min_max_norm, get_napari_version
 
 __all__ = [
     "AListWidget",
@@ -188,7 +189,7 @@ class AListWidget(ListWidget):
         self.viewer.layers.selection.select_only(self.viewer.layers[layer_name])
 
     @singledispatchmethod
-    def _get_points_properties(self, vec: NDArrayA | pd.Series, **kwargs: Any) -> dict[str, Any]:
+    def _get_points_properties(self, vec: ArrayLike | pd.Series, **kwargs: Any) -> dict[str, Any]:
         raise NotImplementedError(type(vec))
 
     @_get_points_properties.register(pd.Series)
@@ -252,7 +253,7 @@ class AListWidget(ListWidget):
         }
 
     @_get_points_properties.register(np.ndarray)
-    def _(self, vec: NDArrayA, **kwargs: Any) -> dict[str, Any]:
+    def _(self, vec: ArrayLike, **kwargs: Any) -> dict[str, Any]:
         layer = kwargs.pop("layer", None)
 
         # Here kwargs['key'] is actually the column name.
@@ -271,9 +272,9 @@ class AListWidget(ListWidget):
             layer_meta = self.model.layer.metadata if self.model.layer is not None else None
             element_indices = pd.Series(layer_meta["indices"], name="element_indices")
             if isinstance(layer, Labels):
-                vec = vec.drop(index=0) if 0 in vec.index else vec  # type:ignore[attr-defined]
+                vec = vec.drop(index=0) if 0 in vec.index else vec
             # element_indices = element_indices[element_indices != 0]
-            diff_element_table = set(element_indices).difference(set(vec.index))  # type:ignore[attr-defined]
+            diff_element_table = set(element_indices).difference(set(vec.index))
             merge_vec = pd.merge(element_indices, vec, left_on="element_indices", right_index=True, how="left")[
                 "vec"
             ].fillna(0, axis=0)
@@ -559,7 +560,7 @@ class RangeSliderWidget(QRangeSlider):
         self._colorbar.setClim((np.min(layer.properties["value"]), np.max(layer.properties["value"])))
         self._colorbar.update_color()
 
-    def _scale_vec(self, vec: NDArrayA) -> NDArrayA:
+    def _scale_vec(self, vec: ArrayLike) -> ArrayLike:
         ominn, omaxx = self._colorbar.getOclim()
         delta = omaxx - ominn + 1e-12
 
@@ -567,7 +568,7 @@ class RangeSliderWidget(QRangeSlider):
         minn = (minn - ominn) / delta
         maxx = (maxx - ominn) / delta
         scaler = MinMaxScaler(feature_range=(minn, maxx))
-        return scaler.fit_transform(vec.reshape(-1, 1))  # type: ignore[no-any-return]
+        return scaler.fit_transform(vec.reshape(-1, 1))
 
     @property
     def viewer(self) -> napari.Viewer:

--- a/src/napari_spatialdata/_widgets.py
+++ b/src/napari_spatialdata/_widgets.py
@@ -542,7 +542,10 @@ class RangeSliderWidget(QRangeSlider):
         if "data" not in layer.metadata:
             return None  # noqa: RET501
         v = layer.metadata["data"]
-        clipped = np.clip(v, *np.percentile(v, percentile))
+        # this code is currently not used since the slider is not enabled; so I silenced the mypy error; 2. there is a
+        # mismatch for this error with the mypy in the CI, so I silenced the unused-ignore from the local mypy.
+        # when this code is re-enabled, let's fix mypy
+        clipped = np.clip(v, *np.percentile(v, percentile))  # type: ignore[misc,unused-ignore]
 
         if isinstance(layer, Points):
             layer.metadata = {**layer.metadata, "perc": percentile}

--- a/src/napari_spatialdata/utils/_test_utils.py
+++ b/src/napari_spatialdata/utils/_test_utils.py
@@ -12,8 +12,7 @@ if TYPE_CHECKING:
 import napari
 from loguru import logger
 from PIL import Image
-
-from napari_spatialdata.utils._utils import NDArrayA
+from spatialdata._types import ArrayLike
 
 
 def get_center_pos_listitem(widget: QListWidget, text: str) -> QPoint:
@@ -72,7 +71,7 @@ def click_list_widget_item(
             raise ValueError(f"{click} is not a valid click")
 
 
-def take_screenshot(viewer: napari.Viewer, canvas_only: bool = False) -> NDArrayA | Any:
+def take_screenshot(viewer: napari.Viewer, canvas_only: bool = False) -> ArrayLike | Any:
     """Take screenshot of the Napari viewer.
 
     Parameters
@@ -84,7 +83,7 @@ def take_screenshot(viewer: napari.Viewer, canvas_only: bool = False) -> NDArray
 
     Returns
     -------
-    The screenshot as an NDArray
+    The screenshot as an array.
     """
     logger.info("Taking screenshot of viewer")
     # to distinguish between the black of the image background and the black of the napari background (now white)
@@ -98,7 +97,7 @@ def take_screenshot(viewer: napari.Viewer, canvas_only: bool = False) -> NDArray
     return interactive_screenshot
 
 
-def save_image(image_np: NDArrayA, file_path: str) -> None:
+def save_image(image_np: ArrayLike, file_path: str) -> None:
     """Save image to file.
 
     Parameters

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -172,7 +172,8 @@ def _min_max_norm(vec: spmatrix | ArrayLike) -> ArrayLike:
     if vec.ndim != 1:
         raise ValueError(f"Expected `1` dimension, found `{vec.ndim}`.")
 
-    maxx, minn = np.nanmax(vec), np.nanmin(vec)
+    maxx: ArrayLike = np.nanmax(vec)
+    minn: ArrayLike = np.nanmin(vec)
 
     return np.ones_like(vec) if np.isclose(minn, maxx) else ((vec - minn) / (maxx - minn))
 

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -47,16 +47,9 @@ if TYPE_CHECKING:
 
     from napari_spatialdata._sdata_widgets import CoordinateSystemWidget, ElementWidget
 
-try:
-    from numpy.typing import NDArray
+from spatialdata._types import ArrayLike
 
-    NDArrayA = NDArray[Any]
-except (ImportError, TypeError):
-    NDArray = np.ndarray  # type: ignore[misc]
-    NDArrayA = np.ndarray  # type: ignore[misc]
-
-
-Vector_name_t = tuple[Optional[Union[pd.Series, NDArrayA]], Optional[str]]
+Vector_name_t = tuple[Optional[Union[pd.Series, ArrayLike]], Optional[str]]
 
 
 def _ensure_dense_vector(fn: Callable[..., Vector_name_t]) -> Callable[..., Vector_name_t]:
@@ -137,7 +130,7 @@ def _get_categorical(
     vec: pd.Series | None = None,
     palette: str | None = None,
     colordict: pd.Series | dict[Any, Any] | None = None,
-) -> NDArrayA:
+) -> ArrayLike:
     categorical = vec if vec is not None else adata.obs[key]
     if not isinstance(colordict, dict):
         col_dict = _set_palette(adata, key, palette, colordict)
@@ -155,7 +148,7 @@ def _get_categorical(
     return np.array([col_dict[v] for v in categorical])
 
 
-def _position_cluster_labels(coords: NDArrayA, clusters: pd.Series) -> dict[str, NDArrayA]:
+def _position_cluster_labels(coords: ArrayLike, clusters: pd.Series) -> dict[str, ArrayLike]:
     if clusters is not None and not isinstance(clusters.dtype, pd.CategoricalDtype):
         raise TypeError(f"Expected `clusters` to be `categorical`, found `{infer_dtype(clusters)}`.")
     coords = coords[:, 1:]
@@ -170,7 +163,7 @@ def _position_cluster_labels(coords: NDArrayA, clusters: pd.Series) -> dict[str,
     return {"clusters": clusters}
 
 
-def _min_max_norm(vec: spmatrix | NDArrayA) -> NDArrayA:
+def _min_max_norm(vec: spmatrix | ArrayLike) -> ArrayLike:
     if issparse(vec):
         if TYPE_CHECKING:
             assert isinstance(vec, spmatrix)
@@ -181,16 +174,14 @@ def _min_max_norm(vec: spmatrix | NDArrayA) -> NDArrayA:
 
     maxx, minn = np.nanmax(vec), np.nanmin(vec)
 
-    return (  # type: ignore[no-any-return]
-        np.ones_like(vec) if np.isclose(minn, maxx) else ((vec - minn) / (maxx - minn))
-    )
+    return np.ones_like(vec) if np.isclose(minn, maxx) else ((vec - minn) / (maxx - minn))
 
 
 def _transform_coordinates(data: list[Any], f: Callable[..., Any]) -> list[Any]:
     return [[f(xy) for xy in sublist] for sublist in data]
 
 
-def _get_transform(element: SpatialElement, coordinate_system_name: str | None = None) -> None | NDArrayA:
+def _get_transform(element: SpatialElement, coordinate_system_name: str | None = None) -> None | ArrayLike:
     if not isinstance(element, (DataArray, DataTree, DaskDataFrame, GeoDataFrame)):
         raise RuntimeError("Cannot get transform for {type(element)}")
 
@@ -198,12 +189,12 @@ def _get_transform(element: SpatialElement, coordinate_system_name: str | None =
     cs = transformations.keys().__iter__().__next__() if coordinate_system_name is None else coordinate_system_name
     ct = transformations.get(cs)
     if ct:
-        return ct.to_affine_matrix(input_axes=("y", "x"), output_axes=("y", "x"))  # type: ignore
+        return ct.to_affine_matrix(input_axes=("y", "x"), output_axes=("y", "x"))
     return None
 
 
 @njit(cache=True, fastmath=True)
-def _point_inside_triangles(triangles: NDArrayA) -> np.bool_:
+def _point_inside_triangles(triangles: ArrayLike) -> np.bool_:
     # modified from napari
     AB = triangles[:, 1, :] - triangles[:, 0, :]
     AC = triangles[:, 2, :] - triangles[:, 0, :]
@@ -217,7 +208,7 @@ def _point_inside_triangles(triangles: NDArrayA) -> np.bool_:
 
 
 @njit(parallel=True)
-def _points_inside_triangles(points: NDArrayA, triangles: NDArrayA) -> NDArrayA:
+def _points_inside_triangles(points: ArrayLike, triangles: ArrayLike) -> ArrayLike:
     out = np.empty(
         len(
             points,
@@ -459,7 +450,7 @@ def generate_random_color_hex() -> str:
     return f"#{randint(0, 255):02x}{randint(0, 255):02x}{randint(0, 255):02x}ff"
 
 
-def _get_ellipses_from_circles(yx: NDArrayA, radii: NDArrayA) -> NDArrayA:
+def _get_ellipses_from_circles(yx: ArrayLike, radii: ArrayLike) -> ArrayLike:
     """Convert circles to ellipses.
 
     Parameters
@@ -471,7 +462,7 @@ def _get_ellipses_from_circles(yx: NDArrayA, radii: NDArrayA) -> NDArrayA:
 
     Returns
     -------
-    NDArrayA
+    ArrayLike
         Ellipses.
     """
     ndim = yx.shape[1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,10 @@ from anndata import AnnData
 from loguru import logger
 from matplotlib.testing.compare import compare_images
 from napari_spatialdata.utils._test_utils import save_image, take_screenshot
-from napari_spatialdata.utils._utils import NDArrayA
 from scipy import ndimage as ndi
 from skimage import data
 from spatialdata import SpatialData
+from spatialdata._types import ArrayLike
 from spatialdata.datasets import blobs
 
 HERE: Path = Path(__file__).parent
@@ -118,7 +118,7 @@ def labels():
     return blobs
 
 
-def _get_blobs_galaxy() -> tuple[NDArrayA, NDArrayA]:
+def _get_blobs_galaxy() -> tuple[ArrayLike, ArrayLike]:
     blobs = data.binary_blobs(rng=SEED)
     blobs = ndi.label(blobs)[0]
     return blobs, data.hubble_deep_field()[: blobs.shape[0], : blobs.shape[0]]

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -10,8 +10,8 @@ from napari.utils.events import EventedList
 from napari_spatialdata._model import DataModel
 from napari_spatialdata._sdata_widgets import SdataWidget
 from napari_spatialdata._view import QtAdataScatterWidget, QtAdataViewWidget
-from napari_spatialdata.utils._utils import NDArrayA
 from spatialdata import SpatialData
+from spatialdata._types import ArrayLike
 
 
 # make_napari_viewer is a pytest fixture that returns a napari viewer object
@@ -51,7 +51,7 @@ def test_creating_widget_with_no_adata(make_napari_viewer: Any, widget: Any) -> 
 def test_model(
     make_napari_viewer: Any,
     widget: Any,
-    labels: NDArrayA,
+    labels: ArrayLike,
     sdata_blobs: SpatialData,
 ) -> None:
     # make viewer and add an image layer using our fixture
@@ -121,7 +121,7 @@ def test_scatterlistwidget(
     make_napari_viewer: Any,
     widget: Any,
     adata_labels: AnnData,
-    image: NDArrayA,
+    image: ArrayLike,
     attr: str,
     item: str,
     text: Union[str, int, None],
@@ -162,7 +162,7 @@ def test_categorical_and_error(
     make_napari_viewer: Any,
     widget: Any,
     adata_labels: AnnData,
-    image: NDArrayA,
+    image: ArrayLike,
     attr: str,
     item: str,
 ) -> None:
@@ -200,7 +200,7 @@ def test_component_widget(
     make_napari_viewer: Any,
     widget: Any,
     adata_labels: AnnData,
-    image: NDArrayA,
+    image: ArrayLike,
 ) -> None:
     viewer = make_napari_viewer()
     layer_name = "labels"
@@ -243,7 +243,7 @@ def test_component_widget(
 
 
 @pytest.mark.parametrize("widget", [QtAdataViewWidget, QtAdataScatterWidget])
-def test_layer_selection(make_napari_viewer: Any, image: NDArrayA, widget: Any, sdata_blobs: SpatialData):
+def test_layer_selection(make_napari_viewer: Any, image: ArrayLike, widget: Any, sdata_blobs: SpatialData):
     viewer = make_napari_viewer()
     sdata_widget = SdataWidget(viewer, EventedList([sdata_blobs]))
     sdata_widget.viewer_model.add_sdata_labels(sdata_blobs, "blobs_labels", "global", False)


### PR DESCRIPTION
The calculation for the radii of transformed circles was wrong. This was manifested for instance when switching between the `global` and `downscaled_hires` coordinate systems in Visium.