### PR TITLE
Fix instance id shift bug; fix obsm viz; fix background color labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-spatialdata)](https://napari-hub.org/plugins/napari-spatialdata)
 [![DOI](https://zenodo.org/badge/477021400.svg)](https://zenodo.org/badge/latestdoi/477021400)
 
-This repository contains a napari plugin for interactively exploring and annotating SpatialData objects. `napari-spatialdata` is part of the `SpatialData` ecosystem. To learn more about SpatialData, please see the [documentation](https://spatialdata.scverse.org/).
+This repository contains a napari plugin for interactively exploring and annotating SpatialData objects. Here you can find the [napari-spatialdata documentation](https://spatialdata.scverse.org/projects/napari/en/latest/notebooks/spatialdata.html). `napari-spatialdata` is part of the `SpatialData` ecosystem. To learn more about SpatialData, please see the [spatialdata documentation](https://spatialdata.scverse.org/).
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 api.md
 cli.md
 contributing.md
+limitations.md
 references.md
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,8 @@
+# Limitations
+
+Contributions are welcomed!
+
+- On macOS, the maximum point size is constrained ([details in the Vispy issue tracker](https://github.com/vispy/vispy/issues/2078));
+  it is important to keep this in mind when zooming in on points to [explore the points property on mouse hover](https://github.com/scverse/napari-spatialdata/issues/35#issuecomment-2383792431).
+- 3D data representation is supported in `spatialdata`; 3D data visualization is supported in `napari`.
+  Still, in `napari-spatialdata` we currently don't support 3D data visualization.

--- a/src/napari_spatialdata/_scatterwidgets.py
+++ b/src/napari_spatialdata/_scatterwidgets.py
@@ -151,11 +151,11 @@ class ScatterListWidget(AListWidget):
 
     def _onAction(self, items: Iterable[str]) -> None:
         for item in sorted(set(items)):
-            try:
-                vec, _ = self._getter(item, index=self.getIndex())
-            except Exception as e:  # noqa: BLE001
-                logger.error(e)
-                continue
+            # try:
+            vec, _, index = self._getter(item, index=self.getIndex())
+            # except Exception as e:  # noqa: BLE001
+            #     logger.error(e)
+            #     continue
             self.chosen = item
             if isinstance(vec, np.ndarray):
                 self.data = vec

--- a/src/napari_spatialdata/_widgets.py
+++ b/src/napari_spatialdata/_widgets.py
@@ -126,14 +126,22 @@ class AListWidget(ListWidget):
                 i = self.model.layer.metadata["adata"].var.index.get_loc(item)
                 self.viewer.dims.set_point(0, i)
             else:
-                vec, name = self._getter(item, index=self.getIndex())
+                vec, name, index = self._getter(item, index=self.getIndex())
 
                 if self.model.layer is not None:
+                    # update the features (properties for each instance displayed on mouse hover in the bottom bar)
+                    self.getIndex()
+                    features_name = f"{item}_{self.getIndex()}" if self._attr == "obsm" else item
+                    features = pd.DataFrame({features_name: vec})
+                    # we need this secret column "index", as explained here
+                    # https://forum.image.sc/t/napari-labels-layer-properties/57649/2
+                    features["index"] = index
+                    self.model.layer.features = features
+
                     properties = self._get_points_properties(vec, key=item, layer=self.model.layer)
                     self.model.color_by = "" if self.model.system_name is None else item
                     if isinstance(self.model.layer, (Points, Shapes)):
                         self.model.layer.text = None  # needed because of the text-feature order of updates
-                        # self.model.layer.features = properties.get("features", None)
                         self.model.layer.face_color = properties["face_color"]
                         # self.model.layer.edge_color = properties["face_color"]
                         self.model.layer.text = properties["text"]
@@ -199,7 +207,7 @@ class AListWidget(ListWidget):
         if isinstance(layer, Labels):
             element_indices = element_indices[element_indices != 0]
         # When merging if the row is not present in the other table it will be nan so we can give it a default color
-        vec_color_name = vec.name + "_color"
+        vec_color_name = vec.name + "_colors"
         if self._attr != "columns_df":
             if vec_color_name not in self.model.adata.uns:
                 colorer = AnnData(shape=(len(vec), 0), obs=pd.DataFrame(index=vec.index, data={"vec": vec}))
@@ -227,7 +235,7 @@ class AListWidget(ListWidget):
                         f"The {vec_color_name} column must have unique values for the each {vec.name} level. Found:\n"
                         f"{unique_colors}"
                     )
-                color_dict = unique_colors.to_dict()[f"{vec.name}_color"]
+                color_dict = unique_colors.to_dict()[f"{vec.name}_colors"]
 
         if self.model.instance_key is not None and self.model.instance_key == vec.index.name:
             merge_df = pd.merge(
@@ -239,7 +247,6 @@ class AListWidget(ListWidget):
         merge_df["color"] = merge_df[vec.name].map(color_dict)
         if layer is not None and isinstance(layer, Labels):
             index_color_mapping = dict(zip(merge_df["element_indices"], merge_df["color"]))
-            index_color_mapping[0] = "#000000ff"
             return {
                 "color": index_color_mapping,
                 "properties": {"value": vec},
@@ -261,6 +268,7 @@ class AListWidget(ListWidget):
             (adata := self.model.adata) is not None
             and kwargs["key"] not in adata.obs.columns
             and kwargs["key"] not in adata.var.index
+            and kwargs["key"] not in adata.obsm
         ) or adata is None:
             merge_vec = layer.metadata["_columns_df"][kwargs["key"]]
             element_indices = merge_vec.index
@@ -289,8 +297,6 @@ class AListWidget(ListWidget):
                     element_indices_list = element_indices.to_list()
                 change_index = element_indices_list.index(i)
                 color_vec[change_index] = np.array([0.5, 0.5, 0.5, 1.0])
-            if isinstance(layer, Labels):
-                color_vec[0] = np.array([0.0, 0.0, 0.0, 1.0])
 
         if layer is not None and isinstance(layer, Labels):
             return {
@@ -440,7 +446,7 @@ class CBarWidget(QtWidgets.QWidget):
             clim=self.getClim(),
             border_width=1.0,
             border_color="black",
-            padding=(0.33, 0.167),
+            padding=(0.3, 0.167),
             axis_ratio=0.05,
         )
 

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -56,29 +56,29 @@ except (ImportError, TypeError):
     NDArrayA = np.ndarray  # type: ignore[misc]
 
 
-Vector_name_t = tuple[Optional[Union[pd.Series, NDArrayA]], Optional[str]]
+Vector_name_index_t = tuple[Optional[Union[pd.Series, NDArrayA]], Optional[str], Optional[pd.Index]]
 
 
-def _ensure_dense_vector(fn: Callable[..., Vector_name_t]) -> Callable[..., Vector_name_t]:
+def _ensure_dense_vector(fn: Callable[..., Vector_name_index_t]) -> Callable[..., Vector_name_index_t]:
     @wraps(fn)
-    def decorator(self: Any, *args: Any, **kwargs: Any) -> Vector_name_t:
+    def decorator(self: Any, *args: Any, **kwargs: Any) -> Vector_name_index_t:
         normalize = kwargs.pop("normalize", False)
-        res, fmt = fn(self, *args, **kwargs)
+        res, name, index = fn(self, *args, **kwargs)
         if res is None:
-            return None, None
+            return None, None, None
 
         if isinstance(res, pd.Series):
             if isinstance(res.dtype, pd.CategoricalDtype):
-                return res, fmt
+                return res, name, index
             if is_string_dtype(res) or is_object_dtype(res) or is_bool_dtype(res):
-                return res.astype("category"), fmt
+                return res.astype("category"), name, index
             if is_integer_dtype(res):
                 unique = res.unique()
                 n_uniq = len(unique)
                 if n_uniq <= 2 and (set(unique) & {0, 1}):
-                    return res.astype(bool).astype("category"), fmt
+                    return res.astype(bool).astype("category"), name, index
                 if len(unique) <= len(res) // 100:
-                    return res.astype("category"), fmt
+                    return res.astype("category"), name, index
             elif not is_numeric_dtype(res):
                 raise TypeError(f"Unable to process `pandas.Series` of type `{infer_dtype(res)}`.")
             res = res.to_numpy()
@@ -93,7 +93,7 @@ def _ensure_dense_vector(fn: Callable[..., Vector_name_t]) -> Callable[..., Vect
         if res.ndim != 1:
             raise ValueError(f"Expected 1-dimensional array, found `{res.ndim}`.")
 
-        return (_min_max_norm(res) if normalize else res), fmt
+        return (_min_max_norm(res) if normalize else res), name, index
 
     return decorator
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from scipy import ndimage as ndi
 from skimage import data
 from spatialdata import SpatialData
 from spatialdata.datasets import blobs
+from spatialdata.models import TableModel
 
 HERE: Path = Path(__file__).parent
 
@@ -42,7 +43,8 @@ def adata_labels() -> AnnData:
         {
             "a": rng.normal(size=(n_obs_labels,)),
             "categorical": pd.Categorical(rng.integers(0, 2, size=(n_obs_labels,))),
-            "cell_id": pd.Categorical(seg),
+            "cell_id": seg,
+            "region": ["labels" for _ in range(n_obs_labels)],
         },
         index=np.arange(n_obs_labels),
     )
@@ -58,7 +60,12 @@ def adata_labels() -> AnnData:
         }
     }
     obsm_labels = {"spatial": rng.integers(0, blobs.shape[0], size=(n_obs_labels, 2))}
-    return generate_adata(n_var, obs_labels, obsm_labels, uns_labels)
+    return TableModel.parse(
+        generate_adata(n_var, obs_labels, obsm_labels, uns_labels),
+        region="labels",
+        region_key="region",
+        instance_key="cell_id",
+    )
 
 
 @pytest.fixture

--- a/tests/test_spatialdata.py
+++ b/tests/test_spatialdata.py
@@ -73,7 +73,7 @@ def test_sdatawidget_images(make_napari_viewer: Any, blobs_extra_cs: SpatialData
     del blobs_extra_cs.images["image"]
 
 
-def test_sdatawidget_labels(make_napari_viewer: Any, blobs_extra_cs: SpatialData):
+def test_sdatawidget_labels(qtbot, make_napari_viewer: Any, blobs_extra_cs: SpatialData):
     viewer = make_napari_viewer()
     widget = SdataWidget(viewer, EventedList([blobs_extra_cs]))
     assert len(widget.viewer_model.viewer.layers) == 0

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -132,7 +132,7 @@ def test_scatterlistwidget(
     viewer.add_labels(
         image,
         name=layer_name,
-        metadata={"adata": adata_labels, "region_key": "cell_id"},
+        metadata={"adata": adata_labels},
     )
     model = DataModel()
     widget = widget(viewer, model)
@@ -173,7 +173,7 @@ def test_categorical_and_error(
     viewer.add_labels(
         image,
         name=layer_name,
-        metadata={"adata": adata_labels, "region_key": "cell_id"},
+        metadata={"adata": adata_labels},
     )
 
     # widget._select_layer()
@@ -208,7 +208,7 @@ def test_component_widget(
     viewer.add_labels(
         image,
         name=layer_name,
-        metadata={"adata": adata_labels, "region_key": "cell_id"},
+        metadata={"adata": adata_labels},
     )
     model = DataModel()
     widget = widget(viewer, model)


### PR DESCRIPTION
Closes #242 

Fixed:
- bugs with `layer.properties`:
    - on mouse hover the layer properties were not shown (this was visible in previous `napari-spatialdata` versions)
    - the correct instance property is now shown; properties were shown for the wrong instance, as reported in #242. 
    - This is available for all the types of annotations `obs`, `var`, `obsm` and dataframe columns.
    - Available for points and labels. Not for shapes, see issue in `napari`: https://github.com/napari/napari/issues/7306
- plotting a continuous variable on a labels caused:
	- the background color to be black instead of transparent; now it's transparent
	- the first instance (no matter which index, for instance `2`) to be black, instead of being of a different color
- plotting variables on `obsm` was not working
- the coloring of categorical variables via pre-saved colors was not working because there was a `"_color"` instead of `"_colors"`
- there were some imprecisions in the tests for the scatterplot widget:
	- the table was not parsed using `TableModel`
	- an unused (and wrong) `region_key` parameter was passed; I removed it
- some modifications in the docs; in particular I warn the user that when zooming in on points in macOS one needs to be careful when looking at the values of points on mouse hover. In fact points that seem to be far away could still be overlapping. Example here: https://github.com/scverse/napari-spatialdata/issues/35#issuecomment-2383792431

Missing (I will track these are new issues)
- tests for plotting data from `obsm`
- tests for hovering with the mouse and checking that the status bar of the viewer shows the correct value