### PR TITLE
fix plot categorical with colors, on labels

### DIFF
--- a/src/napari_spatialdata/_widgets.py
+++ b/src/napari_spatialdata/_widgets.py
@@ -218,7 +218,8 @@ class AListWidget(ListWidget):
                 color_dict = dict(zip(vec.cat.categories, colors, strict=False))
                 color_dict.update({np.nan: "#808080ff"})
             else:
-                color_dict = self.model.adata.uns[vec_color_name]
+                colors = self.model.adata.uns[vec_color_name]
+                color_dict = dict(zip(vec.cat.categories, colors.tolist(), strict=True))
         else:
             df = layer.metadata["_columns_df"]
             if vec_color_name not in df.columns:


### PR DESCRIPTION
When plotting a categorical obs column on labels, for which colors were present in the anndata, an error occurred. This was because the variable `color_dict`, which should be a `dict`, was an array of hex strings instead. 

This part of the code is not covered by tests; we should have tests like in spatialdata-plot, but since we are going to work on visualization interoperability, it makes sense to wait and have a more general way to test the same plots across all the viewers without having to manually duplicate the code and maintain redundant tests. CC @melonora 