### PR TITLE
Fix exception due to adata being none

### DIFF
--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -645,7 +645,7 @@ class QtAdataViewWidget(QWidget):
                 with self.model.events.adata.blocker():
                     self.model.adata = None
 
-        if self.model.adata.shape == (0, 0):
+        if self.model.adata is None or self.model.adata.shape == (0, 0):
             return
 
         self.model.system_name = layer.metadata.get("name", None)

--- a/src/napari_spatialdata/utils/_utils.py
+++ b/src/napari_spatialdata/utils/_utils.py
@@ -382,7 +382,7 @@ def _get_init_metadata_adata(sdata: SpatialData, table_name: str | None, element
         sdata=sdata, spatial_element_names=element_name, table_name=table_name, how="left", match_rows="left"
     )
 
-    if adata.shape[0] == 0:
+    if adata is None or adata.shape[0] == 0:
         return None
     return adata
 


### PR DESCRIPTION
CI is red because of this: https://github.com/scverse/napari-spatialdata/pull/343.

The PR fixes two exception that originated when an annotating table `adata` was `None`. I discovered this bug with this code snippet: https://github.com/scverse/spatialdata/pull/864.