### PR TITLE
fix tests cleanup

### DIFF
--- a/tests/test_spatialdata.py
+++ b/tests/test_spatialdata.py
@@ -11,6 +11,7 @@ from dask.dataframe import from_dask_array
 from multiscale_spatial_image import to_multiscale
 from napari.layers import Image, Labels, Points
 from napari.utils.events import EventedList
+from napari.viewer import Viewer
 from numpy import int64
 from spatialdata import SpatialData, deepcopy
 from spatialdata._core.query.relational_query import get_element_instances
@@ -43,6 +44,7 @@ def test_elementwidget(make_napari_viewer: Any, blobs_extra_cs: SpatialData):
         assert widget._elements[name]["element_type"] == "points"
     for name in blobs_extra_cs.shapes:
         assert widget._elements[name]["element_type"] == "shapes"
+    Viewer.close_all()
 
 
 def test_coordinatewidget(make_napari_viewer: Any, blobs_extra_cs: SpatialData):


### PR DESCRIPTION
Even after the [latest fix](https://github.com/scverse/napari-spatialdata/pull/349), some [tests sometimes fail](https://github.com/scverse/napari-spatialdata/actions/runs/14579292539/job/40892220813) due to improper cleanup. Probably because the fix was not extended to those tests. 

In this PR, I fix only the test that was failing in the CI run above. Two questions for you:
- should we extend this to all the tests in `test_spatialdata.py`?
- IIRC `test_aaa.py` was an experiment to try to fix the sporadically broken tests, and was following some suggestions from [here](https://github.com/scverse/napari-spatialdata/pull/270#discussion_r1731638385). If your fix works, I think we can remove that test. WDYT?