### PR TITLE
Patch headless tests due to `QT_QPA_PLATFORM=offscreen` edgecase

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ readthedocs =
 
 # this is just to trigger pip to check for pre-releases as well
 pre =
-    spatialdata>=0.7.0dev0
+    spatialdata>=0.7.3a1
 
 all =
     napari[pyqt5]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,8 @@ def _patch_napari_gl_for_headless() -> None:
       imported it) – fall back to ``(2048, 2048)`` when the GL query returns 0.
     """
     try:
-        import vispy.gloo.gl._pyopengl2 as _pyopengl2_mod
         import vispy.gloo.gl as _vgl
+        import vispy.gloo.gl._pyopengl2 as _pyopengl2_mod
 
         _orig_get_param = _pyopengl2_mod.glGetParameter
 
@@ -75,11 +75,11 @@ def _patch_napari_gl_for_headless() -> None:
             except Exception:
                 return 2048, 2048
 
-        import napari._vispy.utils.gl as _gl_mod
+        import napari._vispy.canvas as _canvas_mod
+        import napari._vispy.layers.base as _base_mod
         import napari._vispy.layers.image as _img_mod
         import napari._vispy.layers.labels as _lbl_mod
-        import napari._vispy.layers.base as _base_mod
-        import napari._vispy.canvas as _canvas_mod
+        import napari._vispy.utils.gl as _gl_mod
 
         for _mod in (_gl_mod, _img_mod, _lbl_mod, _base_mod, _canvas_mod):
             if hasattr(_mod, "get_max_texture_sizes"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# ruff: noqa: E402
 # MUST set environment variables BEFORE any Qt/napari/vispy imports
 # to enable headless mode in CI environments (Ubuntu/Linux without display)
 import os
@@ -15,8 +16,8 @@ os.environ.setdefault("NAPARI_HEADLESS", "1")
 def _patch_napari_gl_for_headless() -> None:
     """Patch napari's OpenGL utility functions to work without a real display.
 
-    The patch implements two workaround that are no-ops in environments that 
-    have a real display (CI with Xvfb, macOS, local dev). Once the upstreams 
+    The patch implements two workaround that are no-ops in environments that
+    have a real display (CI with Xvfb, macOS, local dev). Once the upstreams
     bugs are addressed this patch should be removed.
 
     In the Qt offscreen platform ``glGetString(GL_EXTENSIONS)`` returns ``None``
@@ -39,8 +40,8 @@ def _patch_napari_gl_for_headless() -> None:
       imported it) – fall back to ``(2048, 2048)`` when the GL query returns 0.
     """
     try:
-        import vispy.gloo.gl._pyopengl2 as _pyopengl2_mod
         import vispy.gloo.gl as _vgl
+        import vispy.gloo.gl._pyopengl2 as _pyopengl2_mod
 
         _orig_get_param = _pyopengl2_mod.glGetParameter
 
@@ -72,23 +73,23 @@ def _patch_napari_gl_for_headless() -> None:
                     max_2d = _vgl.glGetParameter(_vgl.GL_MAX_TEXTURE_SIZE)
                     max_3d = _vgl.glGetParameter(32883)  # GL_MAX_3D_TEXTURE_SIZE
                 return (int(max_2d) if max_2d else 2048, int(max_3d) if max_3d else 2048)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 return 2048, 2048
 
-        import napari._vispy.utils.gl as _gl_mod
+        import napari._vispy.canvas as _canvas_mod
+        import napari._vispy.layers.base as _base_mod
         import napari._vispy.layers.image as _img_mod
         import napari._vispy.layers.labels as _lbl_mod
-        import napari._vispy.layers.base as _base_mod
-        import napari._vispy.canvas as _canvas_mod
+        import napari._vispy.utils.gl as _gl_mod
 
         for _mod in (_gl_mod, _img_mod, _lbl_mod, _base_mod, _canvas_mod):
             if hasattr(_mod, "get_max_texture_sizes"):
                 _mod.get_max_texture_sizes = _safe_get_max_texture_sizes
 
-    except Exception as exc:  # pragma: no cover
+    except Exception as exc:  # noqa: BLE001  # pragma: no cover
         import warnings
 
-        warnings.warn(f"Could not patch napari GL functions for headless mode: {exc}")
+        warnings.warn(f"Could not patch napari GL functions for headless mode: {exc}", stacklevel=2)
 
 
 if os.environ.get("QT_QPA_PLATFORM") == "offscreen":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,90 @@ if sys.platform == "linux":
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 os.environ.setdefault("NAPARI_HEADLESS", "1")
+
+
+def _patch_napari_gl_for_headless() -> None:
+    """Patch napari's OpenGL utility functions to work without a real display.
+
+    This patch should be removed once the problem is addressed upstream.
+
+    In the Qt offscreen platform ``glGetString(GL_EXTENSIONS)`` returns ``None``
+    (raising AttributeError on ``.decode()``) and ``glGetIntegerv`` returns an
+    empty tuple instead of an integer. napari then stores ``None`` as the max
+    texture size, which later crashes ``TiledImageNode``.
+
+    This is a workaround for two upstream bugs — remove this patch once they
+    are fixed:
+
+    * **vispy** – ``vispy/gloo/gl/_pyopengl2.py`` does not guard against
+      ``GL.glGetString()`` returning ``None`` (no valid OpenGL context).
+
+    * **napari** – ``get_gl_extensions()`` and ``get_max_texture_sizes()`` in
+      ``napari/_vispy/utils/gl.py`` do not handle the failure/empty-result
+      case from the underlying GL calls, crashing when run in offscreen mode.
+
+    Fixes applied here:
+    * ``vispy.gloo.gl._pyopengl2.glGetParameter`` – return ``""`` for string
+      queries when the result is ``None``, and ``0`` for empty-tuple results.
+    * ``napari._vispy.utils.gl.get_max_texture_sizes`` (and every module that
+      imported it) – fall back to ``(2048, 2048)`` when the GL query returns 0.
+    """
+    try:
+        import vispy.gloo.gl._pyopengl2 as _pyopengl2_mod
+        import vispy.gloo.gl as _vgl
+
+        _orig_get_param = _pyopengl2_mod.glGetParameter
+
+        def _safe_get_param(pname):  # type: ignore[no-untyped-def]
+            try:
+                result = _orig_get_param(pname)
+            except AttributeError:
+                # glGetString returned None – no valid OpenGL context yet
+                return ""
+            if result is None:
+                return ""
+            if isinstance(result, tuple) and len(result) == 0:
+                return 0
+            return result
+
+        _pyopengl2_mod.glGetParameter = _safe_get_param
+        _vgl.glGetParameter = _safe_get_param
+
+        # get_max_texture_sizes caches (None, None) when GL returns 0/empty;
+        # replace it everywhere it was imported so image layers get valid sizes.
+        from functools import lru_cache
+
+        @lru_cache(maxsize=1)
+        def _safe_get_max_texture_sizes():  # type: ignore[no-untyped-def]
+            try:
+                from napari._vispy.utils.gl import _opengl_context
+
+                with _opengl_context():
+                    max_2d = _vgl.glGetParameter(_vgl.GL_MAX_TEXTURE_SIZE)
+                    max_3d = _vgl.glGetParameter(32883)  # GL_MAX_3D_TEXTURE_SIZE
+                return (int(max_2d) if max_2d else 2048, int(max_3d) if max_3d else 2048)
+            except Exception:
+                return 2048, 2048
+
+        import napari._vispy.utils.gl as _gl_mod
+        import napari._vispy.layers.image as _img_mod
+        import napari._vispy.layers.labels as _lbl_mod
+        import napari._vispy.layers.base as _base_mod
+        import napari._vispy.canvas as _canvas_mod
+
+        for _mod in (_gl_mod, _img_mod, _lbl_mod, _base_mod, _canvas_mod):
+            if hasattr(_mod, "get_max_texture_sizes"):
+                _mod.get_max_texture_sizes = _safe_get_max_texture_sizes
+
+    except Exception as exc:  # pragma: no cover
+        import warnings
+
+        warnings.warn(f"Could not patch napari GL functions for headless mode: {exc}")
+
+
+if os.environ.get("QT_QPA_PLATFORM") == "offscreen":
+    _patch_napari_gl_for_headless()
+
 import random
 import string
 from abc import ABC, ABCMeta

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,16 +15,16 @@ os.environ.setdefault("NAPARI_HEADLESS", "1")
 def _patch_napari_gl_for_headless() -> None:
     """Patch napari's OpenGL utility functions to work without a real display.
 
-    This patch should be removed once the problem is addressed upstream.
+    The patch implements two workaround that are no-ops in environments that 
+    have a real display (CI with Xvfb, macOS, local dev). Once the upstreams 
+    bugs are addressed this patch should be removed.
 
     In the Qt offscreen platform ``glGetString(GL_EXTENSIONS)`` returns ``None``
     (raising AttributeError on ``.decode()``) and ``glGetIntegerv`` returns an
     empty tuple instead of an integer. napari then stores ``None`` as the max
     texture size, which later crashes ``TiledImageNode``.
 
-    This is a workaround for two upstream bugs — remove this patch once they
-    are fixed:
-
+    Upstream bugs:
     * **vispy** – ``vispy/gloo/gl/_pyopengl2.py`` does not guard against
       ``GL.glGetString()`` returning ``None`` (no valid OpenGL context).
 


### PR DESCRIPTION
# Human notes

This patch only affects tests run within certain compute environments. Solution and description below are from Claude. Patch to be removed once the problems are fixed upstream.

# AI notes
## Fix: image layer tests fail in headless mode (`QT_QPA_PLATFORM=offscreen`)

  ### Problem

  When running on Linux without a display (e.g. CI without Xvfb), `QT_QPA_PLATFORM=offscreen` is set so Qt can initialise without a screen. In this configuration, adding any image layer to a      
  napari viewer crashes with two cascading errors:
                                                                                                                                                                                                    
  1. **`AttributeError: 'NoneType' object has no attribute 'decode'`** — `vispy/gloo/gl/_pyopengl2.py` calls `GL.glGetString(GL_EXTENSIONS).decode('utf-8')` without guarding against `None`, which 
  is what the offscreen GL context returns. This propagates out of `napari._vispy.utils.gl.get_gl_extensions()`.
                                                                                                                                                                                                    
  2. **`TypeError: 'NoneType' object cannot be interpreted as an integer`** — in the same context, `glGetIntegerv(GL_MAX_TEXTURE_SIZE)` returns an empty tuple `()`. Because `()` is falsy, napari's
   `get_max_texture_sizes()` converts it to `None` via `if not max_size_2d: max_size_2d = None`, then passes it as `tile_size` to `TiledImageNode`.
                                                                                                                                                                                                    
  The result: any test that adds an image layer fails, and the leaked `QtViewer` object causes all subsequent tests in the same session to error out in setup.

  ### Fix

  `_patch_napari_gl_for_headless()` is added to `conftest.py` and called when `QT_QPA_PLATFORM=offscreen` is detected. It applies two targeted patches before any test runs:                        
   
  - **`vispy.gloo.gl._pyopengl2.glGetParameter`** — returns `""` instead of crashing when `glGetString` returns `None`, and `0` instead of `()` for empty integer results.                          
  - **`napari._vispy.utils.gl.get_max_texture_sizes`** (and the five napari modules that imported it by name) — falls back to `(2048, 2048)` when the GL query returns a zero/empty value.
                                                                                                                                                                                                    
  Both patches are no-ops in environments that have a real display (CI with Xvfb, macOS, local dev).
                                                                                                                                                                                                    
  ### Temporary workaround                                  

  These are upstream bugs that should be fixed in vispy and napari respectively. The patch and this note should be removed once:                                                                    
  - vispy adds a `None` guard in `_pyopengl2.glGetParameter` for string queries
  - napari catches `AttributeError` in `get_gl_extensions()` and uses a non-zero fallback in `get_max_texture_sizes()`                                                                              
                                                                                                                                                                                                   
                                                                                        