### PR TITLE
Fix deprecation GUI warnings for private napari attribute access

### DIFF
--- a/src/napari_spatialdata/_model.py
+++ b/src/napari_spatialdata/_model.py
@@ -28,8 +28,6 @@ class DataModel:
     _layer: Layer = field(init=False, default=None, repr=True)
     _adata: AnnData | None = field(init=False, default=None, repr=True)
     _adata_layer: str | None = field(init=False, default=None, repr=False)
-    _region_key: str | None = field(default=None, repr=True)
-    _instance_key: str | None = field(default=None, repr=True)
     _color_by: str = field(default="", repr=True, init=False)
     _system_name: str | None = field(default=None, repr=True)
 

--- a/src/napari_spatialdata/_view.py
+++ b/src/napari_spatialdata/_view.py
@@ -65,9 +65,7 @@ class QtAdataScatterWidget(QWidget):
             self._viewer = napari_viewer
 
             self._model = (
-                model
-                if model is not None
-                else self._viewer.window._dock_widgets["SpatialData"].widget().viewer_model._model
+                model if model is not None else self._viewer.window.dock_widgets["SpatialData"].viewer_model._model
             )
 
             self._select_layer()
@@ -241,9 +239,8 @@ class QtAdataScatterWidget(QWidget):
 
                     # check that the view widget is present
                     # and trigger its update
-                    if "View (napari-spatialdata)" in dict(self._viewer.window._dock_widgets.items()):
-                        view_widget = dict(self._viewer.window._dock_widgets.items())["View (napari-spatialdata)"]
-                        qtAdataViewWidget = [x for x in view_widget.children() if isinstance(x, QtAdataViewWidget)][0]
+                    if "View (napari-spatialdata)" in self._viewer.window.dock_widgets:
+                        qtAdataViewWidget = self._viewer.window.dock_widgets["View (napari-spatialdata)"]
                         qtAdataViewWidget._on_layer_update()
 
                 # new annotation - update options
@@ -306,9 +303,7 @@ class QtAdataScatterWidget(QWidget):
             selected_table = self.table_name_widget.currentText()
 
             # trigger saving of the table
-            # TODO: have to find another way to pass this as this is deprecated from 0.5.0 onwards
-            # it's used in the save_sdata method
-            self._viewer_model = self._viewer.window._dock_widgets["SpatialData"].widget().viewer_model
+            self._viewer_model = self._viewer.window.dock_widgets["SpatialData"].viewer_model
             self._viewer_model._write_element_to_disk(
                 selected_layer.metadata["sdata"],
                 selected_table,
@@ -611,8 +606,6 @@ class QtAdataViewWidget(QWidget):
         if self.model.adata.shape == (0, 0):
             return
 
-        self.model._region_key = layer.metadata["region_key"] if isinstance(layer, Labels) else None
-        self.model._instance_key = layer.metadata["instance_key"] if isinstance(layer, Labels) else None
         self.model.system_name = layer.metadata.get("name", None)
 
         if hasattr(
@@ -695,8 +688,7 @@ class QtAdataAnnotationWidget(QWidget):
     def __init__(self, napari_viewer: Viewer):
         super().__init__()
         self._viewer = napari_viewer
-        # TODO: have to find another way to pass this as this is deprecated from 0.5.0 onwards
-        self._viewer_model = self._viewer.window._dock_widgets["SpatialData"].widget().viewer_model
+        self._viewer_model = self._viewer.window.dock_widgets["SpatialData"].viewer_model
 
         self.setLayout(QGridLayout())
         self._current_color = "#FFFFFF"


### PR DESCRIPTION
Replace `Window._dock_widgets` with the public `dock_widgets` property (removing now-redundant `.widget()` calls since the public API returns the inner widget directly). Remove dead-code assignments to `DataModel._region_key` and `DataModel._instance_key`, whose backing fields are never read — the public properties derive both values from `get_table_keys(self.adata)` — and drop the unused dataclass fields.