### PR TITLE
Issue with Xenium data and with PyQT

### DIFF
--- a/src/napari_spatialdata/_scatterwidgets.py
+++ b/src/napari_spatialdata/_scatterwidgets.py
@@ -15,7 +15,7 @@ from pandas.api.types import CategoricalDtype
 from pyqtgraph import GraphicsLayoutWidget, GraphicsWidget
 from pyqtgraph.graphicsItems import ROI
 from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
-from pyqtgraph.Qt.QtCore import pyqtSignal
+from qtpy.QtCore import Signal as pyqtSignal
 from pyqtgraph.widgets.ColorButton import ColorButton
 from qtpy.QtCore import QSize, Qt, Signal
 from qtpy.QtGui import QColor, QIcon

--- a/src/napari_spatialdata/utils/_viewer_utils.py
+++ b/src/napari_spatialdata/utils/_viewer_utils.py
@@ -18,7 +18,11 @@ def _get_polygons_properties(df: GeoDataFrame, simplify: bool, include_z: bool) 
     add_z = include_z and "z" in axes
 
     for i in range(len(df)):
-        indices.append(int(df.index[i]))
+        idx = df.index[i]
+        try:
+            indices.append(int(idx))
+        except (ValueError, TypeError):
+            indices.append(idx)
 
         if simplify:
             xy = list(df.geometry.iloc[i].exterior.simplify(tolerance=2).coords)


### PR DESCRIPTION
Hello,

I have had a couple of issues with using napari-spatialdata with Xenium and PySide6. 

The issue with Xenium data was as below 


```python
import os
import sys

os.environ.setdefault("PYQTGRAPH_QT_LIB", "PySide6")
try:
    from pyqtgraph.Qt import QtCore
    if not hasattr(QtCore, "pyqtSignal"):
        QtCore.pyqtSignal = QtCore.Signal
    if not hasattr(QtCore, "pyqtSlot"):
        QtCore.pyqtSlot = QtCore.Slot
except ImportError:
    pass

import numpy as np
import pandas as pd
import geopandas as GeoDataFrame
from shapely.geometry import Polygon
from spatialdata import SpatialData
from spatialdata.models import ShapesModel
from spatialdata.transformations import Identity
from napari_spatialdata import Interactive
import napari

def reproduce_bug():
    # 1. Create a synthetic polygon (a simple square)
    poly = Polygon([(0, 0), (0, 10), (10, 10), (10, 0)])
    
    # 2. Create a GeoDataFrame with a STRING index (simulating Xenium IDs like 'aaaaapcc-1')
    gdf = GeoDataFrame.GeoDataFrame(
        {"geometry": [poly]}, 
        index=["aaaaapcc-1"]
    )
    
    # 3. Wrap it in a SpatialData object
    shapes = ShapesModel.parse(gdf, transformations={"global": Identity()})
    sdata = SpatialData(shapes={"cell_boundaries": shapes})
    
    print("Synthetic SpatialData object created with string index.")
    print(f"Index value: {gdf.index[0]}")
    print("\nAttempting to load into napari-spatialdata...")
    print("EXPECTED BEHAVIOR: The SdataWidget should show 'cell_boundaries'.")
    print("ACTUAL BUG: Double-clicking 'cell_boundaries' or auto-loading it will raise:")
    print("ValueError: invalid literal for int() with base 10: 'aaaaapcc-1'")
    
    # 4. Launch the viewer
    viewer = napari.Viewer()
    interactive = Interactive(sdata, headless=True)
    
    print("\nViewer launched. To trigger the bug:")
    print("1. Locate the 'SpatialData' dock widget on the left.")
    print("2. Double-click 'cell_boundaries'.")
    
    napari.run()

if __name__ == "__main__":
    reproduce_bug()
```

There was also an import issue with PyQT that I had to work around. Both of these are in this pull request.